### PR TITLE
Added doc generation for SC package and submodules

### DIFF
--- a/docs/package.rst
+++ b/docs/package.rst
@@ -151,3 +151,29 @@ highdicom.sr.value\_types module
    :undoc-members:
    :show-inheritance:
 
+
+.. _highdicom-sc-subpackage:
+
+highdicom.sc package
+---------------------
+
+.. automodule:: highdicom.sc
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+highdicom.sc.enum module
++++++++++++++++++++++++++
+
+.. automodule:: highdicom.sc.enum
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+highdicom.sc.sop module
+++++++++++++++++++++++++
+
+.. automodule:: highdicom.sc.sop
+   :members:
+   :undoc-members:
+   :show-inheritance:


### PR DESCRIPTION
Currently the SC package is left out of the API docs.

I updated the package.rst to fix this