### PR TITLE
Voxel representation bug

### DIFF
--- a/src/highdicom/legacy/sop.py
+++ b/src/highdicom/legacy/sop.py
@@ -161,7 +161,7 @@ def _convert_legacy_to_enhanced(
     else:
         mf_dataset.VolumeBasedCalculationTechnique = 'MIXED'
 
-    pixel_representation = 1
+    pixel_representation = sf_datasets[0].PixelRepresentation
     volumetric_properties = 'VOLUME'
     unique_image_types = set()
     unassigned_dataelements = collections.defaultdict(list)


### PR DESCRIPTION
Failure in setting the correct pixel representation attribute of DICOM image while converting from single-frame to multi_frame causes false values in the representation of pixel data (dark negative values in high-intensity CT image voxels).  