### PR TITLE
Added new error messages for segmentation size

### DIFF
--- a/src/highdicom/seg/sop.py
+++ b/src/highdicom/seg/sop.py
@@ -494,6 +494,22 @@ class Segmentation(SOPClass):
                 'rows and columns.'
             )
 
+        # Check the z-dimension of the pixel array
+        src_img = self._source_images[0]
+        is_multiframe = hasattr(src_img, 'NumberOfFrames')
+        if is_multiframe:
+            if pixel_array.shape[0] != src_img.NumberOfFrames:
+                raise ValueError(
+                    'Number of frames in pixel array does not match number of '
+                    'frames in source image.'
+                )
+        else:
+            if pixel_array.shape[0] != len(self._source_images):
+                raise ValueError(
+                    'Number of frames in pixel array does not match number of '
+                    'source images.'
+                )
+
         described_segment_numbers = np.array([
             int(item.SegmentNumber)
             for item in segment_descriptions
@@ -569,8 +585,6 @@ class Segmentation(SOPClass):
             # be sure whether there is overlap with the existing segments
             self.SegmentsOverlap = SegmentsOverlapValues.UNDEFINED.value
 
-        src_img = self._source_images[0]
-        is_multiframe = hasattr(src_img, 'NumberOfFrames')
         if self._coordinate_system == CoordinateSystemNames.SLIDE:
             if hasattr(src_img, 'PerFrameFunctionalGroupsSequence'):
                 source_plane_positions = [
@@ -651,9 +665,9 @@ class Segmentation(SOPClass):
                 source_plane_positions = [
                     PlanePositionSequence(
                         coordinate_system=CoordinateSystemNames.PATIENT,
-                        image_position=src_img.ImagePositionPatient
+                        image_position=img.ImagePositionPatient
                     )
-                    for src_img in self._source_images
+                    for img in self._source_images
                 ]
 
         if plane_positions is None:


### PR DESCRIPTION
Currently, if the user passes a pixel array whose z-dimension does not match the number of frames in the source image (for multislice images) or the number of source images (for single slice series), a ValueError is raised with the error message:

"Number of pixel array planes does not match number of provided image positions"

This error message does not make it clear what the problem is, particularly because in most cases the user will not actually have specified the plane positions explicitly. This caught out a colloborator at CCDS and caused them to ask me for help debugging.

The proposed change adds in new checks earlier in the add_segments method to catch these cases and give a more useful error message.

(I also fixed another case of a loop variable, src_img, clobbering the name of a local variable)