### PR TITLE
Add py.typed to enable mypy typechecking

### DIFF
--- a/src/highdicom/py.typed
+++ b/src/highdicom/py.typed
@@ -1,0 +1,3 @@
+# The presence of this file signifies that the highdicom package contains type
+# annotations in accordance with PEP 561.
+# See https://github.com/MGHComputationalPathology/highdicom/pull/26

--- a/src/highdicom/py.typed
+++ b/src/highdicom/py.typed
@@ -1,3 +1,3 @@
 # The presence of this file signifies that the highdicom package contains type
 # annotations in accordance with PEP 561.
-# See https://github.com/MGHComputationalPathology/highdicom/pull/26
+# See https://mypy.readthedocs.io/en/latest/installed_packages.html


### PR DESCRIPTION
Highdicom has full type annotations that allow mypy to be run to type check the library internals.

However, in accordance with PEP 561 without the presence of the `py.typed` file, mypy will not type perform type checking when user code uses highdicom and will raise an error "cannot find module named highdicom.x.x"

See https://mypy.readthedocs.io/en/latest/installed_packages.html for more information

I have type-checked a simple script with mypy with this file present and validated that it works as expected.