### PR TITLE
Fixed implicit VR flag in SOPClass

### DIFF
--- a/src/highdicom/base.py
+++ b/src/highdicom/base.py
@@ -117,14 +117,10 @@ class SOPClass(Dataset):
             self.is_little_endian = False
         else:
             self.is_little_endian = True
-        if transfer_syntax_uid in (
-                ExplicitVRLittleEndian,
-                ExplicitVRBigEndian,
-                DeflatedExplicitVRLittleEndian
-            ):
-            self.is_implicit_VR = False
-        else:
+        if transfer_syntax_uid == ImplicitVRLittleEndian:
             self.is_implicit_VR = True
+        else:
+            self.is_implicit_VR = False
 
         # Include all File Meta Information required for writing SOP instance
         # to a file in PS3.10 format.


### PR DESCRIPTION
The current behaviour of the `SOPClass` base class with regards to the `is_implicit_VR` property is as follows:

_If the transfer syntax UID is one of the "explicit VR" transfer syntaxes (specifically `ExplicitVRLittleEndian`, `ExplicitVRBigEndian`, `DeflatedExplicitVRLittleEndian`), set to False. Otherwise set to True._

This means that any transfer syntax representing an encapsulated/compressed transfer syntax results in `is_implicit_VR` set to True.

I believe this is incorrect behaviour, and instead the behaviour should be as follows:

_If the transfer syntax UID is `ImplicitVRLittleEndian`, set to True. Otherwise set to False._

Three things make me believe that this is correct:
1. This appears to be the behaviour that the pydicom reading functionality implements, see https://github.com/pydicom/pydicom/blob/f0e8e14ae1019cacaecf7c5f20fee879640f55e9/pydicom/util/leanread.py#L71

2. Empirically checking every pydicom test file suggests that this is the case

3. If you set `is_implicit_VR` to True with an encapsulated transfer syntax and then call `fix_meta_info(enforce_standard=True)` , pydicom will helpfully and silently "correct" the transfer syntax to `ImplicitVRLittleEndian` for you.

The downstream effect of the final point is that in the current implementation, if you try to construct a SOPClass object with a compressed transfer syntax (anything other than `ImplicitVRLittleEndian`, `ExplicitVRLittleEndian`, `ExplicitVRBigEndian`, `DeflatedExplicitVRLittleEndian`), the resulting dataset will be given the transfer syntax `ImplicitVRLittleEndian`. I assume this is not the desired behaviour.

This MR corrects this problem by setting the `is_implicit_VR` flag to match the corrected behaviour described above.