### PR TITLE
Added series description to seg

### DIFF
--- a/src/highdicom/base.py
+++ b/src/highdicom/base.py
@@ -54,7 +54,8 @@ class SOPClass(Dataset):
             ] = None,
             coding_schemes: Optional[
                 Sequence[CodingSchemeIdentificationItem]
-            ] = None
+            ] = None,
+            series_description: Optional[str] = None
         ):
         """
         Parameters
@@ -101,6 +102,8 @@ class SOPClass(Dataset):
         coding_schemes: Sequence[highdicom.sr.coding.CodingSchemeIdentificationItem], optional
             private or public coding schemes that are not part of the
             DICOM standard
+        series_description: str, optional
+            Human readable description of the series
 
         Note
         ----
@@ -161,6 +164,8 @@ class SOPClass(Dataset):
         self.SeriesInstanceUID = str(series_instance_uid)
         self.SeriesNumber = series_number
         self.Modality = modality
+        if series_description is not None:
+            self.SeriesDescription = series_description
 
         # Equipment
         self.Manufacturer = manufacturer

--- a/src/highdicom/seg/sop.py
+++ b/src/highdicom/seg/sop.py
@@ -71,7 +71,6 @@ class Segmentation(SOPClass):
             pixel_measures: Optional[PixelMeasuresSequence] = None,
             plane_orientation: Optional[PlaneOrientationSequence] = None,
             plane_positions: Optional[Sequence[PlanePositionSequence]] = None,
-            series_description: Optional[str] = None,
             **kwargs: Any
         ) -> None:
         """
@@ -168,8 +167,6 @@ class Segmentation(SOPClass):
             of frames in `source_images` (in case of multi-frame source images)
             or the number of `source_images` (in case of single-frame source
             images).
-        series_description: str, optional
-            Human readable description of the series
         **kwargs: Any, optional
             Additional keyword arguments that will be passed to the constructor
             of `highdicom.base.SOPClass`
@@ -275,10 +272,6 @@ class Segmentation(SOPClass):
             'PositionReferenceIndicator',
             None
         )
-
-        # General Series
-        if series_description is not None:
-            self.SeriesDescription = series_description
 
         # (Enhanced) General Equipment
         self.DeviceSerialNumber = device_serial_number

--- a/src/highdicom/seg/sop.py
+++ b/src/highdicom/seg/sop.py
@@ -71,6 +71,7 @@ class Segmentation(SOPClass):
             pixel_measures: Optional[PixelMeasuresSequence] = None,
             plane_orientation: Optional[PlaneOrientationSequence] = None,
             plane_positions: Optional[Sequence[PlanePositionSequence]] = None,
+            series_description: Optional[str] = None,
             **kwargs: Any
         ) -> None:
         """
@@ -167,6 +168,8 @@ class Segmentation(SOPClass):
             of frames in `source_images` (in case of multi-frame source images)
             or the number of `source_images` (in case of single-frame source
             images).
+        series_description: str, optional
+            Human readable description of the series
         **kwargs: Any, optional
             Additional keyword arguments that will be passed to the constructor
             of `highdicom.base.SOPClass`
@@ -272,6 +275,10 @@ class Segmentation(SOPClass):
             'PositionReferenceIndicator',
             None
         )
+
+        # General Series
+        if series_description is not None:
+            self.SeriesDescription = series_description
 
         # (Enhanced) General Equipment
         self.DeviceSerialNumber = device_serial_number

--- a/tests/test_seg.py
+++ b/tests/test_seg.py
@@ -1327,6 +1327,7 @@ class TestSegmentation(unittest.TestCase):
         max_fractional_value = 100
         content_description = 'bla bla bla'
         content_creator_name = 'Me Myself'
+        series_description = 'My First Segmentation'
         instance = Segmentation(
             source_images=[self._ct_image],
             pixel_array=self._ct_pixel_array,
@@ -1343,12 +1344,14 @@ class TestSegmentation(unittest.TestCase):
             fractional_type=fractional_type,
             max_fractional_value=max_fractional_value,
             content_description=content_description,
-            content_creator_name=content_creator_name
+            content_creator_name=content_creator_name,
+            series_description=series_description,
         )
         assert instance.SegmentationFractionalType == fractional_type
         assert instance.MaximumFractionalValue == max_fractional_value
         assert instance.ContentDescription == content_description
         assert instance.ContentCreatorName == content_creator_name
+        assert instance.SeriesDescription == series_description
 
     def test_construction_optional_arguments_2(self):
         pixel_spacing = (0.5, 0.5)


### PR DESCRIPTION
Although optional per the standard, the Series Description is commonly used for a variety of practical purposes. E.g. it is displayed underneath the thumbnail in viewers such as OHIF.

Currently the user can add the series description after construction of the dataset, but since it is so common, I believe that this should be handled as an optional argument of segmentation object.

The only question I have is should this be done at the level of the base SOPClass, to allow other SOPs to benefit from it?