### PR TITLE
3D Fixes and Checks for Spatial Utilities

### DIFF
--- a/src/highdicom/utils.py
+++ b/src/highdicom/utils.py
@@ -371,7 +371,7 @@ def build_inverse_transform(
         image_position: Tuple[float, float, float],
         image_orientation: Tuple[float, float, float, float, float, float],
         pixel_spacing: Tuple[float, float],
-        slice_spacing: float = 1.0
+        spacing_between_slices: float = 1.0
     ) -> np.ndarray:
     """Builds an inverse of an affine transformation matrix for mapping
     coordinates from the three dimensional frame of reference into the two
@@ -394,7 +394,7 @@ def build_inverse_transform(
         (first value: spacing between rows, vertical, top to bottom,
         increasing Row index) and the rows direction (second value: spacing
         between columns: horizontal, left to right, increasing Column index)
-    slice_spacing: float
+    spacing_between_slices: float
         Distance (in the coordinate defined by the Frame of Reference) between
         neighboring slices. Default: 1
 
@@ -414,7 +414,7 @@ def build_inverse_transform(
     row_spacing = float(pixel_spacing[1])  # row direction (between columns)
     rotation[:, 0] *= row_spacing
     rotation[:, 1] *= column_spacing
-    rotation[:, 2] *= slice_spacing
+    rotation[:, 2] *= spacing_between_slices
     inv_rotation = np.linalg.inv(rotation)
     # 4x4 transformation matrix
     return np.row_stack(
@@ -552,7 +552,7 @@ def map_coordinate_into_pixel_matrix(
         image_position: Tuple[float, float, float],
         image_orientation: Tuple[float, float, float, float, float, float],
         pixel_spacing: Tuple[float, float],
-        slice_spacing: float = 1.0,
+        spacing_between_slices: float = 1.0,
     ) -> Tuple[float, float, float]:
     """Maps a coordinate in the physical coordinate system (e.g., Slide or
     Patient) into the pixel matrix.
@@ -576,7 +576,7 @@ def map_coordinate_into_pixel_matrix(
         (first value: spacing between rows, vertical, top to bottom,
         increasing Row index) and the rows direction (second value: spacing
         between columns: horizontal, left to right, increasing Column index)
-    slice_spacing: float
+    spacing_between_slices: float
         Distance (in the coordinate defined by the Frame of Reference) between
         neighboring slices. Default: 1
 
@@ -596,6 +596,6 @@ def map_coordinate_into_pixel_matrix(
         image_position=image_position,
         image_orientation=image_orientation,
         pixel_spacing=pixel_spacing,
-        slice_spacing=slice_spacing
+        spacing_between_slices=spacing_between_slices
     )
     return apply_inverse_transform(coordinate, affine=affine)

--- a/src/highdicom/utils.py
+++ b/src/highdicom/utils.py
@@ -478,12 +478,15 @@ def apply_inverse_transform(
     Returns
     -------
     Tuple[float, float, float]
-        One-based (Column, Row, Slice) index of the Total Pixel Matrix in pixel unit.
-        Note that these values are one-based and in column-major order, which
-        is different from the way NumPy indexes arrays (zero-based and
-        row-major order). Note that in general, the resulting coordinate may not
-        lie within the imaging plane, and consequently the slice index value may be
-        non-zero.
+        One-based (Column, Row, Slice) pixel index. The ``Row`` and ``Column``
+        indices relate to the Total Pixel Matrix in pixel units. ``Slice``
+        represents the signed distance of the input coordinate in the direction
+        normal to the plane of the Total Pixel Matrix represented in units of
+        the given spacing between slices. Note that these values are one-based
+        and in column-major order, which is different from the way NumPy
+        indexes arrays (zero-based and row-major order). Note that in general,
+        the resulting coordinate may not lie within the imaging plane, and
+        consequently the slice index value may be non-zero.
 
     """
     x = float(coordinate[0])
@@ -583,7 +586,14 @@ def map_coordinate_into_pixel_matrix(
     Returns
     -------
     Tuple[float, float, float]
-        (Column, Row, Slice) coordinate in the Total Pixel Matrix
+        (Column, Row, Slice) coordinate. ``Column`` and ``Row`` are pixel
+        coordinates in the Total Pixel Matrix, ``Slice`` represents the signed
+        distance of the input coordinate in the direction normal to the plane
+        of the Total Pixel Matrix represented in units of the given spacing
+        between slices. If the ``Slice`` coordinate is 0.0, then the input
+        coordinate lies in the imaging plane, otherwise it lies off the plane
+        of the Total Pixel Matrix and ``Column`` and ``Row`` may be interpreted
+        as the projections of the input coordinate onto the imaging plane.
 
     Note
     ----

--- a/src/highdicom/utils.py
+++ b/src/highdicom/utils.py
@@ -253,7 +253,7 @@ def create_rotation_matrix(
     """
     row_cosines = np.array(image_orientation[:3])
     column_cosines = np.array(image_orientation[3:])
-    n = np.cross(column_cosines.T, row_cosines.T)
+    n = np.cross(row_cosines.T, column_cosines.T)
     return np.column_stack([
         row_cosines,
         column_cosines,
@@ -442,7 +442,7 @@ def apply_transform(
 def apply_inverse_transform(
         coordinate: Tuple[float, float, float],
         affine: np.ndarray
-    ) -> Tuple[float, float]:
+    ) -> Tuple[float, float, float]:
     """Applies the inverse of an affine transformation matrix to a
     coordinate in the three-dimensional frame of reference to obtain a pixel
     matrix coordinate.
@@ -457,11 +457,13 @@ def apply_inverse_transform(
 
     Returns
     -------
-    Tuple[float, float]
-        One-based (Column, Row) index of the Total Pixel Matrix in pixel unit.
+    Tuple[float, float, float]
+        One-based (Column, Row, Slice) index of the Total Pixel Matrix in pixel unit.
         Note that these values are one-based and in column-major order, which
         is different from the way NumPy indexes arrays (zero-based and
-        row-major order)
+        row-major order). Note that in general, the resulting coordinate may not
+        lie within the imaging plane, and consequently the slice index value may be
+        non-zero.
 
     """
     x = float(coordinate[0])
@@ -469,7 +471,7 @@ def apply_inverse_transform(
     z = float(coordinate[2])
     physical_coordinate = np.array([[x, y, z, 1.0]])
     pixel_matrix_coordinate = np.dot(affine, physical_coordinate.T)
-    return tuple(pixel_matrix_coordinate[:2].flatten().tolist())
+    return tuple(pixel_matrix_coordinate[:3].flatten().tolist())
 
 
 def map_pixel_into_coordinate_system(
@@ -560,8 +562,8 @@ def map_coordinate_into_pixel_matrix(
 
     Returns
     -------
-    Tuple[float, float]
-        (Column, Row) coordinate in the Total Pixel Matrix
+    Tuple[float, float, float]
+        (Column, Row, Slice) coordinate in the Total Pixel Matrix
 
     Note
     ----

--- a/src/highdicom/utils.py
+++ b/src/highdicom/utils.py
@@ -301,6 +301,12 @@ def compute_rotation(
             "reference coordinate system by a simple planar rotation"
         )
     rotation = create_rotation_matrix(image_orientation)
+    if rotation[2, 2] < 0.0:
+        raise ValueError(
+            "The provided image orientation indicates that the image "
+            "coordinate system is flipped relative to the frame of "
+            "reference coordinate system"
+        )
     angle = np.arctan2(-rotation[0, 1], rotation[0, 0])
     if in_degrees:
         return np.degrees(angle)

--- a/src/highdicom/utils.py
+++ b/src/highdicom/utils.py
@@ -268,6 +268,9 @@ def compute_rotation(
     """Computes the rotation of the image with respect to the frame of
     reference (patient or slide coordinate system).
 
+    This is only valid if the two coordinate systems are related via a planar
+    rotation. Otherwise, an exception is raised.
+
     Parameters
     ----------
     image_orientation: Tuple[float, float, float, float, float, float]
@@ -285,7 +288,18 @@ def compute_rotation(
         Angle (in radians or degrees, depending on whether `in_degrees`
         is ``False`` or ``True``, respectively)
 
+    Raises
+    ------
+    ValueError
+        If the provided image orientation is not related to the frame of
+        reference coordinate system by a rotation within the image plane.
+
     """
+    if (image_orientation[2] != 0.0) or (image_orientation[5] != 0.0):
+        raise ValueError(
+            "The provided image orientation is not related to the frame of "
+            "reference coordinate system by a simple planar rotation"
+        )
     rotation = create_rotation_matrix(image_orientation)
     angle = np.arctan2(-rotation[0, 1], rotation[0, 0])
     if in_degrees:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -453,6 +453,13 @@ def test_compute_rotation(inputs, expected_output):
     assert output == expected_output
 
 
+def test_compute_rotation_out_of_plane():
+    orientation = (0.0, 1.0, 0.0, 0.0, 0.0, -1.0)
+    with pytest.raises(ValueError):
+        compute_rotation(orientation)
+
+
+
 @pytest.mark.parametrize('inputs,expected_output', params_physical_to_pixel)
 def test_map_coordinate_into_pixel_matrix(inputs, expected_output):
     output = map_coordinate_into_pixel_matrix(**inputs)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -154,28 +154,28 @@ params_pixel_to_physical = [
 params_rotation = [
     pytest.param(
         dict(
-            image_orientation=(0.0, 1.0, 0.0, 1.0, 0.0, 0.0),
+            image_orientation=(0.0, -1.0, 0.0, 1.0, 0.0, 0.0),
             in_degrees=True
         ),
         -90.0,
     ),
     pytest.param(
         dict(
-            image_orientation=(0.0, -1.0, 0.0, -1.0, 0.0, 0.0),
+            image_orientation=(0.0, 1.0, 0.0, -1.0, 0.0, 0.0),
             in_degrees=True
         ),
         90.0,
     ),
     pytest.param(
         dict(
-            image_orientation=(1.0, 0.0, 0.0, 0.0, -1.0, 0.0),
+            image_orientation=(1.0, 0.0, 0.0, 0.0, 1.0, 0.0),
             in_degrees=True
         ),
-        -0.0,
+        0.0,
     ),
     pytest.param(
         dict(
-            image_orientation=(-1.0, 0.0, 0.0, 0.0, 1.0, 0.0),
+            image_orientation=(-1.0, 0.0, 0.0, 0.0, -1.0, 0.0),
             in_degrees=True
         ),
         -180.0,
@@ -457,7 +457,6 @@ def test_compute_rotation_out_of_plane():
     orientation = (0.0, 1.0, 0.0, 0.0, 0.0, -1.0)
     with pytest.raises(ValueError):
         compute_rotation(orientation)
-
 
 
 @pytest.mark.parametrize('inputs,expected_output', params_physical_to_pixel)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -191,7 +191,7 @@ params_physical_to_pixel = [
             image_orientation=(0.0, 1.0, 0.0, 1.0, 0.0, 0.0),
             pixel_spacing=(1.0, 1.0),
         ),
-        (0.0, 0.0),
+        (0.0, 0.0, 0.0),
     ),
     pytest.param(
         dict(
@@ -200,7 +200,7 @@ params_physical_to_pixel = [
             image_orientation=(0.0, 1.0, 0.0, 1.0, 0.0, 0.0),
             pixel_spacing=(1.0, 1.0),
         ),
-        (0.0, 0.0),
+        (0.0, 0.0, 0.0),
     ),
     pytest.param(
         dict(
@@ -209,7 +209,7 @@ params_physical_to_pixel = [
             image_orientation=(0.0, 1.0, 0.0, 1.0, 0.0, 0.0),
             pixel_spacing=(1.0, 1.0),
         ),
-        (0.0, 0.0),
+        (0.0, 0.0, 0.0),
     ),
     pytest.param(
         dict(
@@ -218,7 +218,7 @@ params_physical_to_pixel = [
             image_orientation=(0.0, 1.0, 0.0, 1.0, 0.0, 0.0),
             pixel_spacing=(1.0, 1.0),
         ),
-        (0.0, 0.0),
+        (0.0, 0.0, 0.0),
     ),
     pytest.param(
         dict(
@@ -227,7 +227,7 @@ params_physical_to_pixel = [
             image_orientation=(0.0, 1.0, 0.0, 1.0, 0.0, 0.0),
             pixel_spacing=(1.0, 1.0),
         ),
-        (1.0, 1.0),
+        (1.0, 1.0, 0.0),
     ),
     pytest.param(
         dict(
@@ -236,7 +236,7 @@ params_physical_to_pixel = [
             image_orientation=(0.0, 1.0, 0.0, 1.0, 0.0, 0.0),
             pixel_spacing=(0.5, 0.5),
         ),
-        (1.0, 1.0),
+        (1.0, 1.0, 0.0),
     ),
     pytest.param(
         dict(
@@ -245,7 +245,7 @@ params_physical_to_pixel = [
             image_orientation=(0.0, 1.0, 0.0, 1.0, 0.0, 0.0),
             pixel_spacing=(2.0, 0.5),
         ),
-        (5.0, 2.0),
+        (5.0, 2.0, 0.0),
     ),
     pytest.param(
         dict(
@@ -254,7 +254,7 @@ params_physical_to_pixel = [
             image_orientation=(0.0, -1.0, 0.0, -1.0, 0.0, 0.0),
             pixel_spacing=(2.0, 0.5),
         ),
-        (5.0, 2.0),
+        (5.0, 2.0, 0.0),
     ),
     pytest.param(
         dict(
@@ -263,7 +263,7 @@ params_physical_to_pixel = [
             image_orientation=(0.0, -1.0, 0.0, -1.0, 0.0, 0.0),
             pixel_spacing=(2.0, 0.5),
         ),
-        (2.0, 2.0),
+        (2.0, 2.0, 0.0),
     ),
     pytest.param(
         dict(
@@ -272,7 +272,7 @@ params_physical_to_pixel = [
             image_orientation=(0.0, -1.0, 0.0, -1.0, 0.0, 0.0),
             pixel_spacing=(2.0, 0.5),
         ),
-        (2.0, 4.0),
+        (2.0, 4.0, 0.0),
     ),
     pytest.param(
         dict(
@@ -281,7 +281,7 @@ params_physical_to_pixel = [
             image_orientation=(1.0, 0.0, 0.0, 0.0, -1.0, 0.0),
             pixel_spacing=(2.0, 0.5),
         ),
-        (5.0, 2.0),
+        (5.0, 2.0, 0.0),
     ),
     pytest.param(
         dict(
@@ -290,7 +290,7 @@ params_physical_to_pixel = [
             image_orientation=(1.0, 0.0, 0.0, 0.0, -1.0, 0.0),
             pixel_spacing=(2.0, 0.5),
         ),
-        (5.0, 4.0),
+        (5.0, 4.0, 0.0),
     ),
     pytest.param(
         dict(
@@ -299,7 +299,7 @@ params_physical_to_pixel = [
             image_orientation=(1.0, 0.0, 0.0, 0.0, -1.0, 0.0),
             pixel_spacing=(2.0, 0.5),
         ),
-        (5.0, 4.0),
+        (5.0, 4.0, 0.0),
     ),
     # Patient
     pytest.param(
@@ -309,7 +309,16 @@ params_physical_to_pixel = [
             image_orientation=(1.0, 0.0, 0.0, 0.0, 1.0, 0.0),
             pixel_spacing=(2.0, 0.5),
         ),
-        (5.0, 4.0),
+        (5.0, 4.0, 0.0),
+    ),
+    pytest.param(
+        dict(
+            coordinate=(89.0, 47.0, -10.0),
+            image_position=(10.0, 60.0, 0.0),
+            image_orientation=(1.0, 0.0, 0.0, 0.0, 1.0, 0.0),
+            pixel_spacing=(2.0, 0.5),
+        ),
+        (158.0, -6.5, -10.0),
     ),
     pytest.param(
         dict(
@@ -318,7 +327,26 @@ params_physical_to_pixel = [
             image_orientation=(0.0, 1.0, 0.0, 0.0, 0.0, -1.0),
             pixel_spacing=(0.25, 0.5),
         ),
-        (15.0, 87.0),
+        (15.0, 87.0, 0.0),
+    ),
+    pytest.param(
+        dict(
+            coordinate=(-35.0, 32.5, -60.5),
+            image_position=(-45.0, 35.0, -90.0),
+            image_orientation=(0.0, 1.0, 0.0, 0.0, 0.0, -1.0),
+            pixel_spacing=(0.25, 0.5),
+        ),
+        (-5.0, -118.0, -10.0),
+    ),
+    pytest.param(
+        dict(
+            coordinate=(-35.0, 32.5, -60.5),
+            image_position=(-45.0, 35.0, -90.0),
+            image_orientation=(0.0, 1.0, 0.0, 0.0, 0.0, -1.0),
+            pixel_spacing=(0.25, 0.5),
+            slice_spacing=0.25
+        ),
+        (-5.0, -118.0, -40.0),
     ),
 ]
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -344,7 +344,7 @@ params_physical_to_pixel = [
             image_position=(-45.0, 35.0, -90.0),
             image_orientation=(0.0, 1.0, 0.0, 0.0, 0.0, -1.0),
             pixel_spacing=(0.25, 0.5),
-            slice_spacing=0.25
+            spacing_between_slices=0.25
         ),
         (-5.0, -118.0, -40.0),
     ),


### PR DESCRIPTION
This pull request fixes some issues with the existing coordinate functions that are relevant to images that have image orientations out of the physical space x, y plane, or relate to out of plane coordinates in physical space.

Specifically:
* A bug fix in `create_rotation_matrix` that meant that the third unit vector had the incorrect sign
* The `apply_inverse_transform` and `map_coordinate_into_pixel_matrix` now return 3D coordinates, where previously they returned 2D coordinates. This is because passing an arbitrary 3D physical space coordinate will in general not result in a pixel index that lies within the plane of the image. Another possible option would be to have the functions throw an error if the 3D physical space coordinate lies out of the imaging plane, but in my opinion this option is more general and more useful, and the user can always check themselves whether the 3rd element of the returned pixel coordinate is zero.
* In order to correctly implement the above point, an optional `slice_spacing` parameter may be passed to `apply_inverse_transform` and `map_coordinate_into_pixel_matrix` to allow for calculation of slice offsets when the spacing between consecutive slices in a series or multiframe image is not 1.0.
* Added new checks in the `compute_rotation` function. As written, the output of this function only makes sense if the imaging plane is related to the x,y plane of the frame of reference coordinate system. If the imaging plane is not related to the frame of reference coordinate system in this way, either because it is tilted out of the x-y plane or because it is an improper rotation of the x-y plane (i.e. a mirror image of a rotated version of the physical x-y plane), then the return value from this function is misleading. This PR adds new checks that will raise an exception in these situations to ensure that the function cannot be accidentally misused.

Furthermore, additional tests cases are added for the coordinate transformation functions that test their behaviour with image orientations going into the third dimension, or and physical space coordinates that are out of plane.