### PR TITLE
Make Algoritithm Identification Sequence optional when using manual segmentations

### DIFF
--- a/src/highdicom/seg/content.py
+++ b/src/highdicom/seg/content.py
@@ -28,7 +28,7 @@ class SegmentDescription(Dataset):
             segmented_property_category: Union[Code, CodedConcept],
             segmented_property_type: Union[Code, CodedConcept],
             algorithm_type: Union[SegmentAlgorithmTypeValues, str],
-            algorithm_identification: AlgorithmIdentificationSequence,
+            algorithm_identification: Optional[AlgorithmIdentificationSequence] = None,
             tracking_uid: Optional[str] = None,
             tracking_id: Optional[str] = None,
             anatomic_regions: Optional[
@@ -57,7 +57,7 @@ class SegmentDescription(Dataset):
             Type of algorithm
         algorithm_identification: highdicom.content.AlgorithmIdentificationSequence, optional
             Information useful for identification of the algorithm, such
-            as its name or version
+            as its name or version. Required unless the algorithm type is `MANUAL`
         tracking_uid: str, optional
             Unique tracking identifier (universally unique)
         tracking_id: str, optional
@@ -93,9 +93,16 @@ class SegmentDescription(Dataset):
         ]
         algorithm_type = SegmentAlgorithmTypeValues(algorithm_type)
         self.SegmentAlgorithmType = algorithm_type.value
-        self.SegmentAlgorithmName = algorithm_identification[0].AlgorithmName
-        self.SegmentationAlgorithmIdentificationSequence = \
-            algorithm_identification
+        if algorithm_identification is None:
+            if self.SegmentAlgorithmType != SegmentAlgorithmTypeValues.MANUAL:
+                raise TypeError(
+                    "Algorithm identification sequence is required unless "
+                    "the segmentation type is MANUAL"
+                )
+        else:
+            self.SegmentAlgorithmName = algorithm_identification[0].AlgorithmName
+            self.SegmentationAlgorithmIdentificationSequence = \
+                algorithm_identification
         num_given_tracking_identifiers = sum([
             tracking_id is not None,
             tracking_uid is not None

--- a/src/highdicom/seg/content.py
+++ b/src/highdicom/seg/content.py
@@ -94,7 +94,7 @@ class SegmentDescription(Dataset):
         algorithm_type = SegmentAlgorithmTypeValues(algorithm_type)
         self.SegmentAlgorithmType = algorithm_type.value
         if algorithm_identification is None:
-            if self.SegmentAlgorithmType != SegmentAlgorithmTypeValues.MANUAL:
+            if self.SegmentAlgorithmType != SegmentAlgorithmTypeValues.MANUAL.value:
                 raise TypeError(
                     "Algorithm identification sequence is required unless "
                     "the segmentation type is MANUAL"

--- a/src/highdicom/seg/content.py
+++ b/src/highdicom/seg/content.py
@@ -28,7 +28,9 @@ class SegmentDescription(Dataset):
             segmented_property_category: Union[Code, CodedConcept],
             segmented_property_type: Union[Code, CodedConcept],
             algorithm_type: Union[SegmentAlgorithmTypeValues, str],
-            algorithm_identification: Optional[AlgorithmIdentificationSequence] = None,
+            algorithm_identification: Optional[
+                AlgorithmIdentificationSequence
+            ] = None,
             tracking_uid: Optional[str] = None,
             tracking_id: Optional[str] = None,
             anatomic_regions: Optional[
@@ -94,13 +96,17 @@ class SegmentDescription(Dataset):
         algorithm_type = SegmentAlgorithmTypeValues(algorithm_type)
         self.SegmentAlgorithmType = algorithm_type.value
         if algorithm_identification is None:
-            if self.SegmentAlgorithmType != SegmentAlgorithmTypeValues.MANUAL.value:
+            if (
+                self.SegmentAlgorithmType !=
+                SegmentAlgorithmTypeValues.MANUAL.value
+            ):
                 raise TypeError(
-                    "Algorithm identification sequence is required unless "
-                    "the segmentation type is MANUAL"
+                    "Algorithm identification sequence is required "
+                    "unless the segmentation type is MANUAL"
                 )
         else:
-            self.SegmentAlgorithmName = algorithm_identification[0].AlgorithmName
+            self.SegmentAlgorithmName = \
+                algorithm_identification[0].AlgorithmName
             self.SegmentationAlgorithmIdentificationSequence = \
                 algorithm_identification
         num_given_tracking_identifiers = sum([

--- a/src/highdicom/seg/sop.py
+++ b/src/highdicom/seg/sop.py
@@ -373,7 +373,7 @@ class Segmentation(SOPClass):
             # same physical dimensions
             # seg_row_dim = self.Rows * pixel_measures[0].PixelSpacing[0]
             # seg_col_dim = self.Columns * pixel_measures[0].PixelSpacing[1]
-            # src_row_dim = src_img.Rows 
+            # src_row_dim = src_img.Rows
 
         if is_multiframe:
             if self._coordinate_system == CoordinateSystemNames.SLIDE:

--- a/tests/test_seg.py
+++ b/tests/test_seg.py
@@ -219,6 +219,17 @@ class TestSegmentDescription(unittest.TestCase):
                 algorithm_type=self._segment_algorithm_type
             )
 
+    def test_construction_no_algo_id_manual_seg(self):
+        # Omitting the algo id should not give an error if the segmentation
+        # type is MANUAL
+        SegmentDescription(
+            segment_number=self._segment_number,
+            segment_label=self._segment_label,
+            segmented_property_category=self._segmented_property_category,
+            segmented_property_type=self._segmented_property_type,
+            algorithm_type=SegmentAlgorithmTypeValues.MANUAL
+        )
+
     def test_construction_optional_argument(self):
         item = SegmentDescription(
             segment_number=self._segment_number,


### PR DESCRIPTION
Currently, the `algorithm_identification` parameter is always a required parameter for a `SegmentDescription` object. (notably the the docstring lists it as optional and therefore does not match the actual `__init__` method's signature).

The SegmentationAlgorithmIdentificationSequence is a type 3 (optional) tag within a SegmentSequence ([see here](https://dicom.innolitics.com/ciods/segmentation/segmentation-image/00620002/00620007)). Currently highdicom also deduces the value of the SegmentAlgorithmName tag from the `algorithm_identifier` parameter. The SegmentAlgorithmName is a type 1C tag, required on the condition that the algorithm type is not `MANUAL` ([see here](https://dicom.innolitics.com/ciods/segmentation/segmentation-image/00620002/00620009)).

In the spirit of being opinionated, I think it is reasonable to require the full algorithm identification parameter for automatic or semi-automatic segmentations even though this is stricter than the standard. However it probably does not make sense to require this parameter when the segmentation is a manual one.

Therefore this PR implements the logic that the `algorithm_identification` is required unless the `algorithm_type` is `MANUAL`. 