### PR TITLE
CID Links in Documentation

### DIFF
--- a/src/highdicom/seg/content.py
+++ b/src/highdicom/seg/content.py
@@ -48,11 +48,13 @@ class SegmentDescription(Dataset):
         segmented_property_category: Union[pydicom.sr.coding.Code, highdicom.sr.coding.CodedConcept]
             Category of the property the segment represents,
             e.g. ``Code("49755003", "SCT", "Morphologically Abnormal Structure")``
-            (see CID 7150 Segmentation Property Categories)
+            (see `CID 7150 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_7150.html>`_
+            "Segmentation Property Categories")
         segmented_property_type: Union[pydicom.sr.coding.Code, highdicom.sr.coding.CodedConcept]
             Property the segment represents,
             e.g. ``Code("108369006", "SCT", "Neoplasm")``
-            (see CID 7151 Segmentation Property Types)
+            (see `CID 7151 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_7151.html>`_
+            "Segmentation Property Types")
         algorithm_type: Union[str, highdicom.seg.enum.SegmentAlgorithmTypeValues]
             Type of algorithm
         algorithm_identification: highdicom.content.AlgorithmIdentificationSequence, optional
@@ -65,7 +67,8 @@ class SegmentDescription(Dataset):
         anatomic_regions: Sequence[Union[pydicom.sr.coding.Code, highdicom.sr.coding.CodedConcept]], optional
             Anatomic region(s) into which segment falls,
             e.g. ``Code("41216001", "SCT", "Prostate")``
-            (see CID 4 Anatomic Region, CID 4031 Common Anatomic Regions, as
+            (see `CID 4 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_4.html>`_
+            "Anatomic Region", `CID 4031 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_4031.html>`_ "Common Anatomic Regions", as
             as well as other CIDs for domain-specific anatomic regions)
         primary_anatomic_structures: Sequence[Union[highdicom.sr.coding.Code, highdicom.sr.coding.CodedConcept]], optional
             Anatomic structure(s) the segment represents

--- a/src/highdicom/sr/content.py
+++ b/src/highdicom/sr/content.py
@@ -428,7 +428,7 @@ class FindingSite(CodeContentItem):
         """
         Parameters
         ----------
-        anatomic_location: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
+        anatomic_location: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code]
             coded anatomic location (region or structure)
         laterality: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
             coded laterality

--- a/src/highdicom/sr/content.py
+++ b/src/highdicom/sr/content.py
@@ -432,7 +432,8 @@ class FindingSite(CodeContentItem):
             coded anatomic location (region or structure)
         laterality: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
             coded laterality
-            (see CID 244 "Laterality" for options)
+            (see `CID 244 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_244.html>`_
+            "Laterality" for options)
         topographical_modifier: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
             coded modifier of anatomic location
 

--- a/src/highdicom/sr/templates.py
+++ b/src/highdicom/sr/templates.py
@@ -293,7 +293,7 @@ class MeasurementStatisticalProperties(Template):
             authority for a description of the reference population of
             measurements
 
-        """
+        """  # noqa: E501
         super().__init__()
         if not isinstance(values, (list, tuple)):
             raise TypeError('Argument "values" must be a list.')
@@ -352,7 +352,7 @@ class NormalRangeProperties(Template):
         authority: str, optional
             authority for the description of the normal range
 
-        """
+        """  # noqa: E501
         super().__init__()
         if not isinstance(values, (list, tuple)):
             raise TypeError('Argument "values" must be a list.')
@@ -793,7 +793,7 @@ class SubjectContextSpecimen(Template):
             (see `CID 8103 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_8103.html>`_
             "Anatomic Pathology Specimen Types" for options)
 
-        """
+        """  # noqa: E501
         super().__init__()
         specimen_uid_item = UIDRefContentItem(
             name=CodedConcept(

--- a/src/highdicom/sr/templates.py
+++ b/src/highdicom/sr/templates.py
@@ -180,7 +180,8 @@ class TimePointContext(Template):
             actual value represention of the time point
         time_point_type: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
             coded type of time point, e.g., "Baseline" or "Posttreatment"
-            (see CID 646 "Time Point Types" for options)
+            (see `CID 6146 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_6146.html>`_
+            "Time Point Types" for options)
         time_point_order: int, optional
             number indicating the order of a time point relative to other
             time points in a time series
@@ -282,8 +283,10 @@ class MeasurementStatisticalProperties(Template):
         values: Sequence[highdicom.sr.value_types.NumContentItem]
             reference values of the population of measurements, e.g., its
             mean or standard deviation
-            (see CID 226 "Population Statistical Descriptors" and
-            CID 227 227 "Sample Statistical Descriptors" for options)
+            (see `CID 226 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_226.html>`_
+            "Population Statistical Descriptors" and
+            `CID 227 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_227.html>`_
+            "Sample Statistical Descriptors" for options)
         description: str, optional
             description of the reference population of measurements
         authority: str, optional
@@ -342,7 +345,8 @@ class NormalRangeProperties(Template):
         values: Sequence[highdicom.sr.value_types.NumContentItem]
             reference values of the normal range, e.g., its upper and lower
             bound
-            (see CID 223 "Normal Range Values" for options)
+            (see `CID 223 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_223.html>`_
+            "Normal Range Values" for options)
         description: str, optional
             description of the normal range
         authority: str, optional
@@ -397,14 +401,17 @@ class MeasurementProperties(Template):
         ----------
         normality: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
             the extend to which the measurement is considered normal or abnormal
-            (see CID 222 "Normality Codes" for options)
+            (see `CID 222 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_222.html>`_
+            "Normality Codes" for options)
         level_of_significance: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
             the extend to which the measurement is considered normal or abnormal
-            (see CID 220 "Level of Significance" for options)
+            (see `CID 220 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_220.html>`_
+            "Level of Significance" for options)
         selection_status: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
             how the measurement value was selected or computed from a set of
             available values
-            (see CID 224 "Selection Method" for options)
+            (see `CID 224 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_224.html>`_
+            "Selection Method" for options)
         measurement_statistical_properties: highdicom.sr.templates.MeasurementStatisticalProperties, optional
             statistical properties of a reference population for a measurement
             and/or the position of a measurement in such a reference population
@@ -688,7 +695,8 @@ class ObserverContext(Template):
         ----------
         observer_type: highdicom.sr.coding.CodedConcept
             type of observer
-            (see CID 270 "Observer Type" for options)
+            (see `CID 270 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_270.html>`_
+            "Observer Type" for options)
         observer_identifying_attributes: Union[highdicom.sr.templates.PersonObserverIdentifyingAttributes, highdicom.sr.templates.DeviceObserverIdentifyingAttributes]
             observer identifying attributes
 
@@ -782,7 +790,8 @@ class SubjectContextSpecimen(Template):
             slide)
         specimen_type: highdicom.sr.coding.CodedConcept, optional
             type of the specimen
-            (see CID 8103 "Anatomic Pathology Specimen Types" for options)
+            (see `CID 8103 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_8103.html>`_
+            "Anatomic Pathology Specimen Types" for options)
 
         """
         super().__init__()
@@ -939,7 +948,8 @@ class SubjectContext(Template):
         ----------
         subject_class: highdicom.sr.coding.CodedConcept
             type of subject if the subject of the report is not the patient
-            (see CID 271 "Observation Subject Class" for options)
+            (see `CID 271 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_271.html>`_
+            "Observation Subject Class" for options)
         subject_class_specific_context: Union[highdicom.sr.templates.SubjectContextFetus, highdicom.sr.templates.SubjectContextSpecimen, highdicom.sr.templates.SubjectContextDevice], optional
             additional context information specific to `subject_class`
 
@@ -1065,15 +1075,18 @@ class Measurement(Template):
         ----------
         name: highdicom.sr.coding.CodedConcept
             Name of the measurement
-            (see CID 7469 "Generic Intensity and Size Measurements" and
-            CID 7468 "Texture Measurements" for options)
+            (see `CID 7469 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_7469.html>`_
+            "Generic Intensity and Size Measurements" and
+            `CID 7468 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_7468.html>`_
+            "Texture Measurements" for options)
         tracking_identifier: highdicom.sr.templates.TrackingIdentifier, optional
             Identifier for tracking measurements
         value: Union[int, float], optional
             Numeric measurement value
         unit: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
             Unit of the numeric measurement value
-            (see CID 7181 "Abstract Multi-dimensional Image Model Component
+            (see `CID 7181 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_7181.html>`_
+            "Abstract Multi-dimensional Image Model Component
             Units" for options)
         qualifier: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
             Qualification of numeric measurement value or as an alternative
@@ -1082,14 +1095,16 @@ class Measurement(Template):
             Identification of algorithm used for making measurements
         derivation: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
             How the value was computed
-            (see CID 7464 "General Region of Interest Measurement Modifiers"
+            (see `CID 7464 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_7464.html>`_
+            "General Region of Interest Measurement Modifiers"
             for options)
         finding_sites: Sequence[highdicom.sr.content.FindingSite], optional
             Coded description of one or more anatomic locations corresonding
             to the image region from which measurement was taken
         method: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
             Measurement method
-            (see CID 6147 "Response Criteria" for options)
+            (see `CID 6147 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_6147.html>`_
+            "Response Criteria" for options)
         properties: highdicom.sr.templates.MeasurementProperties, optional
             Measurement properties, including evaluations of its normality
             and/or significance, its relationship to a reference population,
@@ -1215,7 +1230,8 @@ class MeasurementsAndQualitativeEvaluations(Template):
             Type of object that was measured, e.g., organ or tumor
         method: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
             coded measurement method
-            (see CID 6147 "Response Criteria" for options)
+            (see `CID 6147 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_6147.html>`_
+            "Response Criteria" for options)
         algorithm_id: highdicom.sr.templates.AlgorithmIdentification, optional
             identification of algorithm used for making measurements
         finding_sites: Sequence[highdicom.sr.content.FindingSite], optional
@@ -1386,7 +1402,8 @@ class _ROIMeasurementsAndQualitativeEvaluations(
             type of object that was measured, e.g., organ or tumor
         method: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
             coded measurement method
-            (see CID 6147 "Response Criteria" for options)
+            (see `CID 6147 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_6147.html>`_
+            "Response Criteria" for options)
         algorithm_id: highdicom.sr.templates.AlgorithmIdentification, optional
             identification of algorithm used for making measurements
         finding_sites: Sequence[highdicom.sr.content.FindingSite], optional
@@ -1401,7 +1418,8 @@ class _ROIMeasurementsAndQualitativeEvaluations(
             measurements in qualitative terms
         geometric_purpose: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
             geometric interpretation of region of interest
-            (see CID 219 "Geometry Graphical Representation" for options)
+            (see `CID 219 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_219.html>`_
+            "Geometry Graphical Representation" for options)
 
         Note
         ----
@@ -1527,7 +1545,8 @@ class PlanarROIMeasurementsAndQualitativeEvaluations(
             type of object that was measured, e.g., organ or tumor
         method: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
             coded measurement method
-            (see CID 6147 "Response Criteria" for options)
+            (see `CID 6147 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_6147.html>`_
+            "Response Criteria" for options)
         algorithm_id: highdicom.sr.templates.AlgorithmIdentification, optional
             identification of algorithm used for making measurements
         finding_sites: Sequence[highdicom.sr.content.FindingSite], optional
@@ -1542,7 +1561,8 @@ class PlanarROIMeasurementsAndQualitativeEvaluations(
             measurements in qualitative terms for a region of interest
         geometric_purpose: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
             geometric interpretation of region of interest
-            (see CID 219 "Geometry Graphical Representation" for options)
+            (see `CID 219 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_219.html>`_
+            "Geometry Graphical Representation" for options)
 
         Note
         ----
@@ -1631,7 +1651,8 @@ class VolumetricROIMeasurementsAndQualitativeEvaluations(
             type of object that was measured, e.g., organ or tumor
         method: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
             coded measurement method
-            (see CID 6147 "Response Criteria" for options)
+            (see `CID 6147 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_6147.html>`_
+            "Response Criteria" for options)
         algorithm_id: highdicom.sr.templates.AlgorithmIdentification, optional
             identification of algorithm used for making measurements
         finding_sites: Sequence[highdicom.sr.content.FindingSite], optional
@@ -1646,7 +1667,8 @@ class VolumetricROIMeasurementsAndQualitativeEvaluations(
             measurements in qualitative terms for a volume of interest
         geometric_purpose: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
             geometric interpretation of region of interest
-            (see CID 219 "Geometry Graphical Representation" for options)
+            (see `CID 219 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_219.html>`_
+            "Geometry Graphical Representation" for options)
 
         Note
         ----
@@ -1692,8 +1714,9 @@ class MeasurementsDerivedFromMultipleROIMeasurements(Template):
         derivation: Sequence[highdicom.sr.coding.CodedConcept]
             methods for derivation of measurements from multiple ROIs
             measurements
-            (see CID 7465 "Measurements Derived From Multiple ROI Measurements"
-            for otions)
+            (see `CID 7465 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_7465.html>`_
+            "Measurements Derived From Multiple ROI Measurements"
+            for options)
         measurement_groups: Union[Sequence[highdicom.sr.templates.PlanarROIMeasurementsAndQualitativeEvaluations], Sequence[highdicom.sr.templates.VolumetricROIMeasurementsAndQualitativeEvaluations]]
             one or more groups of either planar or volumetric ROI measurements
             and qualitative evaluations
@@ -1765,8 +1788,8 @@ class MeasurementReport(Template):
             description of the observation context
         procedure_reported: Union[Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], Sequence[Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code]]]
             one or more coded description(s) of the procedure
-            (see CID 100 "Quantitative Diagnostic Imaging Procedures" for
-            options)
+            (see `CID 100 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_100.html>`_
+            "Quantitative Diagnostic Imaging Procedures" for options)
         imaging_measurements: Sequence[Union[highdicom.sr.templates.PlanarROIMeasurementsAndQualitativeEvaluations, highdicom.sr.templates.VolumetricROIMeasurementsAndQualitativeEvaluations, highdicom.sr.templates.MeasurementsAndQualitativeEvaluations]], optional
             measurements and qualitative evaluations of images or regions
             within images
@@ -1775,8 +1798,9 @@ class MeasurementReport(Template):
             within images
             qualitative evaluations of images
         title: highdicom.sr.coding.CodedConcept, optional
-            title of the report
-            (see CID 7021 "Measurement Report Document Titles" for options)
+            title of the report (see 
+            `CID 7021 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_7021.html>`_
+            "Measurement Report Document Titles" for options)
         language_of_content_item_and_descendants: highdicom.sr.templates.LanguageOfContentItemAndDescendants, optional
             specification of the language of report content items
             (defaults to English)

--- a/src/highdicom/sr/templates.py
+++ b/src/highdicom/sr/templates.py
@@ -179,8 +179,8 @@ class TimePointContext(Template):
         time_point: str
             actual value represention of the time point
         time_point_type: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
-            coded type of time point, e.g., "Baseline" or "Posttreatment"
-            (see `CID 6146 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_6146.html>`_
+            coded type of time point, e.g., "Baseline" or "Posttreatment" (see
+            `CID 6146 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_6146.html>`_
             "Time Point Types" for options)
         time_point_order: int, optional
             number indicating the order of a time point relative to other
@@ -282,8 +282,8 @@ class MeasurementStatisticalProperties(Template):
         ----------
         values: Sequence[highdicom.sr.value_types.NumContentItem]
             reference values of the population of measurements, e.g., its
-            mean or standard deviation
-            (see `CID 226 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_226.html>`_
+            mean or standard deviation (see
+            `CID 226 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_226.html>`_
             "Population Statistical Descriptors" and
             `CID 227 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_227.html>`_
             "Sample Statistical Descriptors" for options)
@@ -344,8 +344,8 @@ class NormalRangeProperties(Template):
         ----------
         values: Sequence[highdicom.sr.value_types.NumContentItem]
             reference values of the normal range, e.g., its upper and lower
-            bound
-            (see `CID 223 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_223.html>`_
+            bound (see
+            `CID 223 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_223.html>`_
             "Normal Range Values" for options)
         description: str, optional
             description of the normal range
@@ -409,8 +409,8 @@ class MeasurementProperties(Template):
             "Level of Significance" for options)
         selection_status: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
             how the measurement value was selected or computed from a set of
-            available values
-            (see `CID 224 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_224.html>`_
+            available values (see
+            `CID 224 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_224.html>`_
             "Selection Method" for options)
         measurement_statistical_properties: highdicom.sr.templates.MeasurementStatisticalProperties, optional
             statistical properties of a reference population for a measurement
@@ -694,8 +694,8 @@ class ObserverContext(Template):
         Parameters
         ----------
         observer_type: highdicom.sr.coding.CodedConcept
-            type of observer
-            (see `CID 270 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_270.html>`_
+            type of observer (see
+            `CID 270 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_270.html>`_
             "Observer Type" for options)
         observer_identifying_attributes: Union[highdicom.sr.templates.PersonObserverIdentifyingAttributes, highdicom.sr.templates.DeviceObserverIdentifyingAttributes]
             observer identifying attributes
@@ -789,8 +789,8 @@ class SubjectContextSpecimen(Template):
             identifier of the container holding the speciment (e.g., a glass
             slide)
         specimen_type: highdicom.sr.coding.CodedConcept, optional
-            type of the specimen
-            (see `CID 8103 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_8103.html>`_
+            type of the specimen (see
+            `CID 8103 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_8103.html>`_
             "Anatomic Pathology Specimen Types" for options)
 
         """  # noqa: E501
@@ -1074,8 +1074,8 @@ class Measurement(Template):
         Parameters
         ----------
         name: highdicom.sr.coding.CodedConcept
-            Name of the measurement
-            (see `CID 7469 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_7469.html>`_
+            Name of the measurement (see
+            `CID 7469 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_7469.html>`_
             "Generic Intensity and Size Measurements" and
             `CID 7468 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_7468.html>`_
             "Texture Measurements" for options)
@@ -1084,8 +1084,8 @@ class Measurement(Template):
         value: Union[int, float], optional
             Numeric measurement value
         unit: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
-            Unit of the numeric measurement value
-            (see `CID 7181 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_7181.html>`_
+            Unit of the numeric measurement value (see
+            `CID 7181 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_7181.html>`_
             "Abstract Multi-dimensional Image Model Component
             Units" for options)
         qualifier: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
@@ -1094,16 +1094,16 @@ class Measurement(Template):
         algorithm_id: highdicom.sr.templates.AlgorithmIdentification, optional
             Identification of algorithm used for making measurements
         derivation: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
-            How the value was computed
-            (see `CID 7464 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_7464.html>`_
+            How the value was computed (see
+            `CID 7464 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_7464.html>`_
             "General Region of Interest Measurement Modifiers"
             for options)
         finding_sites: Sequence[highdicom.sr.content.FindingSite], optional
             Coded description of one or more anatomic locations corresonding
             to the image region from which measurement was taken
         method: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
-            Measurement method
-            (see `CID 6147 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_6147.html>`_
+            Measurement method (see
+            `CID 6147 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_6147.html>`_
             "Response Criteria" for options)
         properties: highdicom.sr.templates.MeasurementProperties, optional
             Measurement properties, including evaluations of its normality
@@ -1229,8 +1229,8 @@ class MeasurementsAndQualitativeEvaluations(Template):
         finding_type: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
             Type of object that was measured, e.g., organ or tumor
         method: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
-            coded measurement method
-            (see `CID 6147 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_6147.html>`_
+            coded measurement method (see
+            `CID 6147 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_6147.html>`_
             "Response Criteria" for options)
         algorithm_id: highdicom.sr.templates.AlgorithmIdentification, optional
             identification of algorithm used for making measurements
@@ -1401,8 +1401,8 @@ class _ROIMeasurementsAndQualitativeEvaluations(
         finding_type: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
             type of object that was measured, e.g., organ or tumor
         method: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
-            coded measurement method
-            (see `CID 6147 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_6147.html>`_
+            coded measurement method (see
+            `CID 6147 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_6147.html>`_
             "Response Criteria" for options)
         algorithm_id: highdicom.sr.templates.AlgorithmIdentification, optional
             identification of algorithm used for making measurements
@@ -1417,8 +1417,8 @@ class _ROIMeasurementsAndQualitativeEvaluations(
             coded name-value (question-answer) pairs that describe the
             measurements in qualitative terms
         geometric_purpose: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
-            geometric interpretation of region of interest
-            (see `CID 219 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_219.html>`_
+            geometric interpretation of region of interest (see
+            `CID 219 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_219.html>`_
             "Geometry Graphical Representation" for options)
 
         Note
@@ -1544,8 +1544,8 @@ class PlanarROIMeasurementsAndQualitativeEvaluations(
         finding_type: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
             type of object that was measured, e.g., organ or tumor
         method: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
-            coded measurement method
-            (see `CID 6147 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_6147.html>`_
+            coded measurement method (see
+            `CID 6147 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_6147.html>`_
             "Response Criteria" for options)
         algorithm_id: highdicom.sr.templates.AlgorithmIdentification, optional
             identification of algorithm used for making measurements
@@ -1560,8 +1560,8 @@ class PlanarROIMeasurementsAndQualitativeEvaluations(
             coded name-value (question-answer) pairs that describe the
             measurements in qualitative terms for a region of interest
         geometric_purpose: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
-            geometric interpretation of region of interest
-            (see `CID 219 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_219.html>`_
+            geometric interpretation of region of interest (see
+            `CID 219 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_219.html>`_
             "Geometry Graphical Representation" for options)
 
         Note
@@ -1650,8 +1650,8 @@ class VolumetricROIMeasurementsAndQualitativeEvaluations(
         finding_type: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
             type of object that was measured, e.g., organ or tumor
         method: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
-            coded measurement method
-            (see `CID 6147 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_6147.html>`_
+            coded measurement method (see
+            `CID 6147 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_6147.html>`_
             "Response Criteria" for options)
         algorithm_id: highdicom.sr.templates.AlgorithmIdentification, optional
             identification of algorithm used for making measurements
@@ -1666,8 +1666,8 @@ class VolumetricROIMeasurementsAndQualitativeEvaluations(
             coded name-value (question-answer) pairs that describe the
             measurements in qualitative terms for a volume of interest
         geometric_purpose: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
-            geometric interpretation of region of interest
-            (see `CID 219 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_219.html>`_
+            geometric interpretation of region of interest (see
+            `CID 219 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_219.html>`_
             "Geometry Graphical Representation" for options)
 
         Note
@@ -1713,8 +1713,8 @@ class MeasurementsDerivedFromMultipleROIMeasurements(Template):
         ----------
         derivation: Sequence[highdicom.sr.coding.CodedConcept]
             methods for derivation of measurements from multiple ROIs
-            measurements
-            (see `CID 7465 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_7465.html>`_
+            measurements (see
+            `CID 7465 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_7465.html>`_
             "Measurements Derived From Multiple ROI Measurements"
             for options)
         measurement_groups: Union[Sequence[highdicom.sr.templates.PlanarROIMeasurementsAndQualitativeEvaluations], Sequence[highdicom.sr.templates.VolumetricROIMeasurementsAndQualitativeEvaluations]]
@@ -1787,8 +1787,8 @@ class MeasurementReport(Template):
         observation_context: highdicom.sr.templates.ObservationContext
             description of the observation context
         procedure_reported: Union[Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], Sequence[Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code]]]
-            one or more coded description(s) of the procedure
-            (see `CID 100 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_100.html>`_
+            one or more coded description(s) of the procedure (see
+            `CID 100 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_100.html>`_
             "Quantitative Diagnostic Imaging Procedures" for options)
         imaging_measurements: Sequence[Union[highdicom.sr.templates.PlanarROIMeasurementsAndQualitativeEvaluations, highdicom.sr.templates.VolumetricROIMeasurementsAndQualitativeEvaluations, highdicom.sr.templates.MeasurementsAndQualitativeEvaluations]], optional
             measurements and qualitative evaluations of images or regions

--- a/src/highdicom/sr/value_types.py
+++ b/src/highdicom/sr/value_types.py
@@ -401,12 +401,14 @@ class NumContentItem(ContentItem):
         value: Union[int, float], optional
             numeric value
         unit: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
-            coded units of measurement (see CID 7181 "Abstract Multi-dimensional
+            coded units of measurement (see `CID 7181 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_7181.html>`_
+            "Abstract Multi-dimensional
             Image Model Component Units")
         qualifier: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
             qualification of numeric value or as an alternative to
             numeric value, e.g., reason for absence of numeric value
-            (see CID 42 "Numeric Value Qualifier" for options)
+            (see `CID 42 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_42.html>`_
+            "Numeric Value Qualifier" for options)
         relationship_type: Union[highdicom.sr.enum.RelationshipTypeValues, str], optional
             type of relationship with parent content item
 

--- a/src/highdicom/sr/value_types.py
+++ b/src/highdicom/sr/value_types.py
@@ -402,8 +402,7 @@ class NumContentItem(ContentItem):
             numeric value
         unit: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
             coded units of measurement (see `CID 7181 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_7181.html>`_
-            "Abstract Multi-dimensional
-            Image Model Component Units")
+            "Abstract Multi-dimensional Image Model Component Units")
         qualifier: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
             qualification of numeric value or as an alternative to
             numeric value, e.g., reason for absence of numeric value


### PR DESCRIPTION
Every time a docstring refers to specific CID, I have added a hyperlink to the DICOM standard's page for that CID. I hope this makes using the docs considerably more convenient.

I checked every link and in so doing found and corrected a mistake: Time Point Type (CID 6146) was mistakenly listed as CID 646 "Preclinical Small Animal Imaging Procedures". Oopsie

In case it's ever useful again, here is a handy vim substitution command:
```
:%s#CID \([0-9]*\)#`CID \1 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_\1.html>`_\r           #c
```