### PR TITLE
SR Template tests to improve coverage

### DIFF
--- a/src/highdicom/seg/sop.py
+++ b/src/highdicom/seg/sop.py
@@ -373,7 +373,7 @@ class Segmentation(SOPClass):
             # same physical dimensions
             # seg_row_dim = self.Rows * pixel_measures[0].PixelSpacing[0]
             # seg_col_dim = self.Columns * pixel_measures[0].PixelSpacing[1]
-            # src_row_dim = src_img.Rows 
+            # src_row_dim = src_img.Rows
 
         if is_multiframe:
             if self._coordinate_system == CoordinateSystemNames.SLIDE:

--- a/src/highdicom/sr/templates.py
+++ b/src/highdicom/sr/templates.py
@@ -177,7 +177,7 @@ class TimePointContext(Template):
         Parameters
         ----------
         time_point: str
-            actual value represention of the time point
+            actual value representation of the time point
         time_point_type: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
             coded type of time point, e.g., "Baseline" or "Posttreatment"
             (see CID 646 "Time Point Types" for options)
@@ -194,7 +194,7 @@ class TimePointContext(Template):
            particular protocol using the same value for different subjects
         temporal_offset_from_event: highdicom.sr.content.LongitudinalTemporalOffsetFromEvent, optional
             offset in time from a particular event of significance, e.g., the
-            baseline of an imaging study or enrollment into a clincal trial
+            baseline of an imaging study or enrollment into a clinical trial
         temporal_event_type: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
             type of event to which `temporal_offset_from_event` is relative,
             e.g., "Baseline" or "Enrollment"

--- a/tests/test_sr.py
+++ b/tests/test_sr.py
@@ -85,12 +85,11 @@ class TestAlgorithmIdentification(unittest.TestCase):
         )
         assert len(algo_id) == 2
         assert algo_id[0].ConceptNameCodeSequence[0].CodeValue == \
-                codes.DCM.AlgorithmName.value
+            codes.DCM.AlgorithmName.value
         assert algo_id[0].TextValue == self._name
         assert algo_id[1].ConceptNameCodeSequence[0].CodeValue == \
-                codes.DCM.AlgorithmVersion.value
+            codes.DCM.AlgorithmVersion.value
         assert algo_id[1].TextValue == self._version
-
 
     def test_construction_parameters(self):
         algo_id = AlgorithmIdentification(
@@ -100,14 +99,14 @@ class TestAlgorithmIdentification(unittest.TestCase):
         )
         assert len(algo_id) == 2 + len(self._parameters)
         assert algo_id[0].ConceptNameCodeSequence[0].CodeValue == \
-                codes.DCM.AlgorithmName.value
+            codes.DCM.AlgorithmName.value
         assert algo_id[0].TextValue == self._name
         assert algo_id[1].ConceptNameCodeSequence[0].CodeValue == \
-                codes.DCM.AlgorithmVersion.value
+            codes.DCM.AlgorithmVersion.value
         assert algo_id[1].TextValue == self._version
         for i, param in enumerate(self._parameters, start=2):
             assert algo_id[i].ConceptNameCodeSequence[0].CodeValue == \
-                    codes.DCM.AlgorithmParameters.value
+                codes.DCM.AlgorithmParameters.value
             assert algo_id[i].TextValue == param
 
 
@@ -115,8 +114,8 @@ class TestMeasurementStatisticalProperties(unittest.TestCase):
 
     def setUp(self):
         super().setUp()
-        self._value_name=codes.SCT.Volume
-        self._value_unit=codes.UCUM.CubicMillimeter
+        self._value_name = codes.SCT.Volume
+        self._value_unit = codes.UCUM.CubicMillimeter
         self._value_number = 0.12345
         self._values = [
             NumContentItem(
@@ -134,9 +133,9 @@ class TestMeasurementStatisticalProperties(unittest.TestCase):
         )
         assert len(stat_props) == 1
         assert stat_props[0].ConceptNameCodeSequence[0].CodeValue == \
-                self._value_name.value
+            self._value_name.value
         assert str(stat_props[0].MeasuredValueSequence[0].NumericValue) == \
-                str(self._value_number)
+            str(self._value_number)
 
     def test_construction_description(self):
         stat_props = MeasurementStatisticalProperties(
@@ -145,11 +144,11 @@ class TestMeasurementStatisticalProperties(unittest.TestCase):
         )
         assert len(stat_props) == 2
         assert stat_props[0].ConceptNameCodeSequence[0].CodeValue == \
-                self._value_name.value
+            self._value_name.value
         assert str(stat_props[0].MeasuredValueSequence[0].NumericValue) == \
-                str(self._value_number)
+            str(self._value_number)
         assert stat_props[1].ConceptNameCodeSequence[0].CodeValue == \
-                codes.DCM.PopulationDescription.value
+            codes.DCM.PopulationDescription.value
 
 
 class TestCodedConcept(unittest.TestCase):
@@ -677,7 +676,7 @@ class TestSubjectContextDevice(unittest.TestCase):
         context = SubjectContextDevice(name=self._name)
         assert len(context) == 1
         assert context[0].ConceptNameCodeSequence[0].CodeValue == \
-                codes.DCM.DeviceSubjectName.value
+            codes.DCM.DeviceSubjectName.value
         assert context[0].TextValue == self._name
 
     def test_construction_all(self):
@@ -691,22 +690,22 @@ class TestSubjectContextDevice(unittest.TestCase):
         )
         assert len(context) == 6
         assert context[0].ConceptNameCodeSequence[0].CodeValue == \
-                codes.DCM.DeviceSubjectName.value
+            codes.DCM.DeviceSubjectName.value
         assert context[0].TextValue == self._name
         assert context[1].ConceptNameCodeSequence[0].CodeValue == \
-                codes.DCM.DeviceSubjectUID.value
+            codes.DCM.DeviceSubjectUID.value
         assert context[1].UID == self._uid
         assert context[2].ConceptNameCodeSequence[0].CodeValue == \
-                codes.DCM.DeviceSubjectManufacturer.value
+            codes.DCM.DeviceSubjectManufacturer.value
         assert context[2].TextValue == self._manufacturer
         assert context[3].ConceptNameCodeSequence[0].CodeValue == \
-                codes.DCM.DeviceSubjectModelName.value
+            codes.DCM.DeviceSubjectModelName.value
         assert context[3].TextValue == self._model_name
         assert context[4].ConceptNameCodeSequence[0].CodeValue == \
-                codes.DCM.DeviceSubjectSerialNumber.value
+            codes.DCM.DeviceSubjectSerialNumber.value
         assert context[4].TextValue == self._serial_number
         assert context[5].ConceptNameCodeSequence[0].CodeValue == \
-                codes.DCM.DeviceSubjectPhysicalLocationDuringObservation.value
+            codes.DCM.DeviceSubjectPhysicalLocationDuringObservation.value
         assert context[5].TextValue == self._physical_location
 
 


### PR DESCRIPTION
Test coverage on master is currently below the threshold and is causing tests on all branches to fail. Coverage is particularly low in the sr templates module. Fixing this fully is substantial work that we can move towards slowly. But for now I quickly implemented tests for three completely untested classes (`AlgorithmIdentification`, `MeasurementStatisticalProperties`, `SubjectContextDevice`) that were responsible for large numbers of lines of untested code to bring us back up over the threshold. After this, coverage is over 75%, giving us a small working buffer.

There's also a flake8 fix and a couple of typo fixes I spotted in the docstrings in the classes I wrote tests for.

Suggest merging this first before merging these changes into the branches for other currently open pull requests.