### PR TITLE
Fix referenced segment bug. Added tests

### DIFF
--- a/src/highdicom/sr/content.py
+++ b/src/highdicom/sr/content.py
@@ -549,11 +549,11 @@ class ReferencedSegment(ContentSequence):
             SOP Class UID of the referenced segmentation object
         sop_instance_uid: str
             SOP Instance UID of the referenced segmentation object
+        segment_number: int
+            number of the segment to which the refernce applies
         frame_numbers: Sequence[int], optional
             numbers of the frames to which the reference applies
             (in case a segmentation instance is referenced)
-        segment_number: int
-            number of the segment to which the refernce applies
         source_images: Sequence[highdicom.sr.content.SourceImageForSegmentation], optional
             source images for segmentation
         source_series: highdicom.sr.content.SourceSeriesForSegmentation, optional

--- a/src/highdicom/sr/templates.py
+++ b/src/highdicom/sr/templates.py
@@ -1499,7 +1499,7 @@ class _ROIMeasurementsAndQualitativeEvaluations(
                     'ReferencedSegment or '
                     'ReferencedSegmentationFrame.'
                 )
-            group_item.ContentSequence.append(referenced_segment)
+            group_item.ContentSequence.extend(referenced_segment)
 
 
 class PlanarROIMeasurementsAndQualitativeEvaluations(

--- a/tests/test_sr.py
+++ b/tests/test_sr.py
@@ -20,6 +20,7 @@ from highdicom.sr.content import (
     VolumeSurface,
     SourceImageForRegion,
     SourceImageForSegmentation,
+    RealWorldValueMap,
     ReferencedSegment,
     ReferencedSegmentationFrame,
     SourceSeriesForSegmentation
@@ -1030,18 +1031,69 @@ class TestPlanarROIMeasurementsAndQualitativeEvaluations(unittest.TestCase):
             uid=generate_uid(),
             identifier='planar roi measurements'
         )
-        self._image = SourceImageForRegion(
+        self._image_for_region = SourceImageForRegion(
+            referenced_sop_class_uid='1.2.840.10008.5.1.4.1.1.2.2',
+            referenced_sop_instance_uid=generate_uid()
+        )
+        self._image_for_segment = SourceImageForSegmentation(
             referenced_sop_class_uid='1.2.840.10008.5.1.4.1.1.2.2',
             referenced_sop_instance_uid=generate_uid()
         )
         self._region = ImageRegion(
             graphic_type=GraphicTypeValues.CIRCLE,
             graphic_data=np.array([[1.0, 1.0], [2.0, 2.0]]),
-            source_image=self._image
+            source_image=self._image_for_region
         )
-        self._measurements = PlanarROIMeasurementsAndQualitativeEvaluations(
+        self._segment = ReferencedSegmentationFrame(
+            sop_class_uid='1.2.840.10008.5.1.4.1.1.66.4',
+            sop_instance_uid=generate_uid(),
+            segment_number=1,
+            frame_number=1,
+            source_image=self._image_for_segment
+        )
+        self._real_world_value_map = RealWorldValueMap(
+            referenced_sop_instance_uid=generate_uid()
+        )
+        self._finding_type = codes.SCT.Nodule
+        self._method = codes.DCM.RECIST1Point1
+        self._algo_id = AlgorithmIdentification(
+            name='Foo Method',
+            version='1.0.1',
+        )
+        self._finding_sites = [
+            FindingSite(
+                anatomic_location=codes.cid7151.LobeOfLung,
+                laterality=codes.cid244.Right,
+                topographical_modifier=codes.cid2.Apical
+            )
+        ]
+        self._session = 'Session 1'
+        self._geometric_purpose = codes.DCM.Center
+
+    def test_construction_with_region(self):
+        PlanarROIMeasurementsAndQualitativeEvaluations(
             tracking_identifier=self._tracking_identifier,
             referenced_region=self._region
+        )
+
+    def test_construction_with_segment(self):
+        PlanarROIMeasurementsAndQualitativeEvaluations(
+            tracking_identifier=self._tracking_identifier,
+            referenced_segment=self._segment
+        )
+
+    def test_construction_all_parameters(self):
+        # TODO add time_point_context, measurements and qualitative evaluations
+        PlanarROIMeasurementsAndQualitativeEvaluations(
+            tracking_identifier=self._tracking_identifier,
+            referenced_region=self._region,
+            referenced_real_world_value_map=self._real_world_value_map,
+            finding_type=self._finding_type,
+            method=self._method,
+            algorithm_id=self._algo_id,
+            finding_sites=self._finding_sites,
+            session=self._session,
+            geometric_purpose=self._geometric_purpose
         )
 
     def test_constructed_without_human_readable_tracking_identifier(self):
@@ -1065,7 +1117,7 @@ class TestPlanarROIMeasurementsAndQualitativeEvaluations(unittest.TestCase):
             PlanarROIMeasurementsAndQualitativeEvaluations(
                 tracking_identifier=self._tracking_identifier,
                 referenced_region=self._region,
-                referenced_segment=self._region
+                referenced_segment=self._segment
             )
 
 
@@ -1077,12 +1129,18 @@ class TestVolumetricROIMeasurementsAndQualitativeEvaluations(unittest.TestCase):
             uid=generate_uid(),
             identifier='volumetric roi measurements'
         )
-        self._images = [
+        self._images_for_region = [
             SourceImageForRegion(
                 referenced_sop_class_uid='1.2.840.10008.5.1.4.1.1.2.2',
                 referenced_sop_instance_uid=generate_uid()
             )
             for i in range(3)
+        ]
+        self._images_for_segment = [
+            SourceImageForSegmentation(
+                referenced_sop_class_uid='1.2.840.10008.5.1.4.1.1.2.2',
+                referenced_sop_instance_uid=generate_uid()
+            )
         ]
         self._regions = [
             ImageRegion(
@@ -1090,13 +1148,59 @@ class TestVolumetricROIMeasurementsAndQualitativeEvaluations(unittest.TestCase):
                 graphic_data=np.array([
                     [1.0, 1.0], [2.0, 2.0], [3.0, 3.0], [1.0, 1.0]
                 ]),
-                source_image=self._images[i]
+                source_image=self._images_for_region[i]
             )
             for i in range(3)
         ]
+        self._segment = ReferencedSegment(
+            sop_class_uid='1.2.840.10008.5.1.4.1.1.66.4',
+            sop_instance_uid=generate_uid(),
+            segment_number=1,
+            source_images=self._images_for_segment
+        )
+        self._real_world_value_map = RealWorldValueMap(
+            referenced_sop_instance_uid=generate_uid()
+        )
+        self._finding_type = codes.SCT.Nodule
+        self._method = codes.DCM.RECIST1Point1
+        self._algo_id = AlgorithmIdentification(
+            name='Foo Method',
+            version='1.0.1',
+        )
+        self._finding_sites = [
+            FindingSite(
+                anatomic_location=codes.cid7151.LobeOfLung,
+                laterality=codes.cid244.Right,
+                topographical_modifier=codes.cid2.Apical
+            )
+        ]
+        self._session = 'Session 1'
+        self._geometric_purpose = codes.DCM.Center
+
+    def test_constructed_with_regions(self):
         self._measurements = VolumetricROIMeasurementsAndQualitativeEvaluations(
             tracking_identifier=self._tracking_identifier,
             referenced_regions=self._regions
+        )
+
+    def test_constructed_with_segment(self):
+        self._measurements = VolumetricROIMeasurementsAndQualitativeEvaluations(
+            tracking_identifier=self._tracking_identifier,
+            referenced_segment=self._segment
+        )
+
+    def test_construction_all_parameters(self):
+        # TODO add time_point_context, measurements and qualitative evaluations
+        VolumetricROIMeasurementsAndQualitativeEvaluations(
+            tracking_identifier=self._tracking_identifier,
+            referenced_regions=self._regions,
+            referenced_real_world_value_map=self._real_world_value_map,
+            finding_type=self._finding_type,
+            method=self._method,
+            algorithm_id=self._algo_id,
+            finding_sites=self._finding_sites,
+            session=self._session,
+            geometric_purpose=self._geometric_purpose
         )
 
     def test_constructed_with_volume(self):


### PR DESCRIPTION
Trying to use `PlanarROIMeasurementsAndQualitativeEvaluations` or `VolumetricROIMeasurementsAndQualitativeEvaluations` while passing the `referenced_segment` parameter resulted in an error because a `ReferencedSegment` is derived from `ContentSequence` not `ContentItem` and therefore cannot be `append`ed to a `ContentSequence`. The one line fix is to `extend` it instead.

I added some test cases to test this in the future, as well as some other parameters of the two templates in order to improve test coverage.

I also corrected the order of the parameters in the `ReferencedSegment` docstring.