### PR TITLE
Remove SCImage laterality parameter

### DIFF
--- a/src/highdicom/sc/sop.py
+++ b/src/highdicom/sc/sop.py
@@ -24,7 +24,6 @@ from highdicom.content import (
 from highdicom.enum import (
     AnatomicalOrientationTypeValues,
     CoordinateSystemNames,
-    LateralityValues,
     PhotometricInterpretationValues,
     PatientOrientationValuesBiped,
     PatientOrientationValuesQuadruped,
@@ -68,7 +67,6 @@ class SCImage(SOPClass):
             study_time: Optional[Union[str, datetime.time]] = None,
             referring_physician_name: Optional[str] = None,
             pixel_spacing: Optional[Tuple[int, int]] = None,
-            laterality: Optional[Union[str, LateralityValues]] = None,
             patient_orientation: Optional[
                 Union[
                     Tuple[str, str],
@@ -145,9 +143,6 @@ class SCImage(SOPClass):
         pixel_spacing: Tuple[int, int], optional
             Physical spacing in millimeter between pixels along the row and
             column dimension
-        laterality: Union[str, highdicom.enum.LateralityValues], optional
-            Laterality of the examined body part (required if
-            `coordinate_system` is ``"PATIENT"``)
         patient_orientation:
                 Union[Tuple[str, str], Tuple[highdicom.enum.PatientOrientationValuesBiped, highdicom.enum.PatientOrientationValuesBiped], Tuple[highdicom.enum.PatientOrientationValuesQuadruped, highdicom.enum.PatientOrientationValuesQuadruped]], optional
             Orientation of the patient along the row and column axes of the
@@ -207,20 +202,11 @@ class SCImage(SOPClass):
 
         coordinate_system = CoordinateSystemNames(coordinate_system)
         if coordinate_system == CoordinateSystemNames.PATIENT:
-            if laterality is None:
-                raise TypeError(
-                    'Laterality is required if coordinate system '
-                    'is "PATIENT".'
-                )
             if patient_orientation is None:
                 raise TypeError(
                     'Patient orientation is required if coordinate system '
                     'is "PATIENT".'
                 )
-
-            # General Series
-            laterality = LateralityValues(laterality)
-            self.Laterality = laterality.value
 
             # General Image
             if anatomical_orientation_type is not None:

--- a/tests/test_sc.py
+++ b/tests/test_sc.py
@@ -22,7 +22,6 @@ class TestSCImage(unittest.TestCase):
         self._series_number = int(np.random.choice(100))
         self._instance_number = int(np.random.choice(100))
         self._manufacturer = 'ABC'
-        self._laterality = 'L'
         self._patient_orientation = ['A', 'R']
         self._container_identifier = str(np.random.choice(100))
         self._specimen_identifier = str(np.random.choice(100))
@@ -53,7 +52,6 @@ class TestSCImage(unittest.TestCase):
             series_number=self._series_number,
             instance_number=self._instance_number,
             manufacturer=self._manufacturer,
-            laterality=self._laterality,
             patient_orientation=self._patient_orientation
         )
         assert instance.BitsAllocated == bits_allocated
@@ -66,7 +64,6 @@ class TestSCImage(unittest.TestCase):
         assert instance.SeriesNumber == self._series_number
         assert instance.InstanceNumber == self._instance_number
         assert instance.Manufacturer == self._manufacturer
-        assert instance.Laterality == self._laterality
         assert instance.PatientOrientation == self._patient_orientation
         assert instance.AccessionNumber is None
         assert instance.PatientName is None
@@ -96,26 +93,6 @@ class TestSCImage(unittest.TestCase):
                 series_number=self._series_number,
                 instance_number=self._instance_number,
                 manufacturer=self._manufacturer,
-                patient_orientation=self._patient_orientation
-            )
-
-    def test_construct_rgb_patient_missing_parameter_1(self):
-        with pytest.raises(TypeError):
-            bits_allocated = 8
-            photometric_interpretation = 'RGB'
-            coordinate_system = 'PATIENT'
-            SCImage(
-                pixel_array=self._rgb_pixel_array,
-                photometric_interpretation=photometric_interpretation,
-                bits_allocated=bits_allocated,
-                coordinate_system=coordinate_system,
-                study_instance_uid=self._study_instance_uid,
-                series_instance_uid=self._series_instance_uid,
-                sop_instance_uid=self._sop_instance_uid,
-                series_number=self._series_number,
-                instance_number=self._instance_number,
-                manufacturer=self._manufacturer,
-                laterality=self._laterality,
             )
 
     def test_construct_rgb_slide_single_specimen(self):
@@ -224,7 +201,6 @@ class TestSCImage(unittest.TestCase):
             series_number=self._series_number,
             instance_number=self._instance_number,
             manufacturer=self._manufacturer,
-            laterality=self._laterality,
             patient_orientation=self._patient_orientation
         )
         assert instance.BitsAllocated == bits_allocated
@@ -236,7 +212,6 @@ class TestSCImage(unittest.TestCase):
         assert instance.SeriesNumber == self._series_number
         assert instance.InstanceNumber == self._instance_number
         assert instance.Manufacturer == self._manufacturer
-        assert instance.Laterality == self._laterality
         assert instance.PatientOrientation == self._patient_orientation
         assert instance.AccessionNumber is None
         assert instance.PatientName is None
@@ -266,7 +241,6 @@ class TestSCImage(unittest.TestCase):
             series_number=self._series_number,
             instance_number=self._instance_number,
             manufacturer=self._manufacturer,
-            laterality=self._laterality,
             patient_orientation=self._patient_orientation,
             transfer_syntax_uid=RLELossless
         )
@@ -294,7 +268,6 @@ class TestSCImage(unittest.TestCase):
             series_number=self._series_number,
             instance_number=self._instance_number,
             manufacturer=self._manufacturer,
-            laterality=self._laterality,
             patient_orientation=self._patient_orientation,
             transfer_syntax_uid=RLELossless
         )


### PR DESCRIPTION
Currently the laterality parameter is required for SCImage if the coordinate system is `PATIENT`. However I believe this is not the correct reading of the standard and propose at least making laterality optional and personally would go further and remove it entirely.

The documentation for the Laterality tag may be found [here](https://dicom.innolitics.com/ciods/secondary-capture-image/general-series/00200060) or [here](http://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_C.7.3.html#table_C.7-5a). It is a type 2C tag that is 

> Required if the body part examined is a paired structure and Image Laterality (0020,0062) or Frame Laterality (0020,9072) or Measurement Laterality (0024,0113) are not.

So it's only required in the situation where the Body Part Examined tag (itself a type 3 tag) is provided (which highdicom provides no mechanism to do) *and* represents a paired structure (e.g. lung, kidney, etc.) which will often not be the case even when Body Part Examined is present. Since highdicom provides no mechanism to provide Body Part Examined, I believe the most consistent thing to do is entirely remove laterality from the SCImage class.

This proposed PR entirely removes the parameter and updates the tests and docs accordingly.
