### PR TITLE
Add back laterality

### DIFF
--- a/src/highdicom/sc/sop.py
+++ b/src/highdicom/sc/sop.py
@@ -25,6 +25,7 @@ from highdicom.enum import (
     AnatomicalOrientationTypeValues,
     CoordinateSystemNames,
     PhotometricInterpretationValues,
+    LateralityValues,
     PatientOrientationValuesBiped,
     PatientOrientationValuesQuadruped,
 )
@@ -67,6 +68,7 @@ class SCImage(SOPClass):
             study_time: Optional[Union[str, datetime.time]] = None,
             referring_physician_name: Optional[str] = None,
             pixel_spacing: Optional[Tuple[int, int]] = None,
+            laterality: Optional[Union[str, LateralityValues]] = None,
             patient_orientation: Optional[
                 Union[
                     Tuple[str, str],
@@ -143,6 +145,8 @@ class SCImage(SOPClass):
         pixel_spacing: Tuple[int, int], optional
             Physical spacing in millimeter between pixels along the row and
             column dimension
+        laterality: Union[str, highdicom.enum.LateralityValues], optional
+            Laterality of the examined body part
         patient_orientation:
                 Union[Tuple[str, str], Tuple[highdicom.enum.PatientOrientationValuesBiped, highdicom.enum.PatientOrientationValuesBiped], Tuple[highdicom.enum.PatientOrientationValuesQuadruped, highdicom.enum.PatientOrientationValuesQuadruped]], optional
             Orientation of the patient along the row and column axes of the
@@ -207,6 +211,11 @@ class SCImage(SOPClass):
                     'Patient orientation is required if coordinate system '
                     'is "PATIENT".'
                 )
+
+            # General Series
+            if laterality is not None:
+                laterality = LateralityValues(laterality)
+                self.Laterality = laterality.value
 
             # General Image
             if anatomical_orientation_type is not None:

--- a/tests/test_sc.py
+++ b/tests/test_sc.py
@@ -22,6 +22,7 @@ class TestSCImage(unittest.TestCase):
         self._series_number = int(np.random.choice(100))
         self._instance_number = int(np.random.choice(100))
         self._manufacturer = 'ABC'
+        self._laterality = 'L'
         self._patient_orientation = ['A', 'R']
         self._container_identifier = str(np.random.choice(100))
         self._specimen_identifier = str(np.random.choice(100))
@@ -52,7 +53,8 @@ class TestSCImage(unittest.TestCase):
             series_number=self._series_number,
             instance_number=self._instance_number,
             manufacturer=self._manufacturer,
-            patient_orientation=self._patient_orientation
+            patient_orientation=self._patient_orientation,
+            laterality=self._laterality
         )
         assert instance.BitsAllocated == bits_allocated
         assert instance.SamplesPerPixel == 3
@@ -64,6 +66,7 @@ class TestSCImage(unittest.TestCase):
         assert instance.SeriesNumber == self._series_number
         assert instance.InstanceNumber == self._instance_number
         assert instance.Manufacturer == self._manufacturer
+        assert instance.Laterality == self._laterality
         assert instance.PatientOrientation == self._patient_orientation
         assert instance.AccessionNumber is None
         assert instance.PatientName is None


### PR DESCRIPTION
Add laterality back as an optional parameter of SCImage, to reverse the backwards incompatible change introduced by #49 