### PR TITLE
Prevent invalid segment numbers

### DIFF
--- a/src/highdicom/seg/content.py
+++ b/src/highdicom/seg/content.py
@@ -23,11 +23,11 @@ class SegmentDescription(Dataset):
 
     def __init__(
             self,
+            segment_number: Optional[int],
             segment_label: str,
             segmented_property_category: Union[Code, CodedConcept],
             segmented_property_type: Union[Code, CodedConcept],
             algorithm_type: Union[SegmentAlgorithmTypeValues, str],
-            segment_number: Optional[int] = None,
             algorithm_identification: Optional[
                 AlgorithmIdentificationSequence
             ] = None,
@@ -43,8 +43,11 @@ class SegmentDescription(Dataset):
         """
         Parameters
         ----------
-        segment_number: int
-            Number of the segment
+        segment_number: Optional[int]
+            Number of the segment. If set to ``None``, no segment number will
+            assigned at this time, and a number will be automatically
+            determined when the description is added to a segmentation
+            instance.
         segment_label: str
             Label of the segment
         segmented_property_category: Union[pydicom.sr.coding.Code, highdicom.sr.coding.CodedConcept]
@@ -79,6 +82,8 @@ class SegmentDescription(Dataset):
         """  # noqa
         super().__init__()
         if segment_number is not None:
+            if segment_number < 1:
+                raise ValueError("Segment number must be a positive integer")
             self.SegmentNumber = segment_number
         self.SegmentLabel = segment_label
         self.SegmentedPropertyCategoryCodeSequence = [

--- a/src/highdicom/seg/content.py
+++ b/src/highdicom/seg/content.py
@@ -23,7 +23,7 @@ class SegmentDescription(Dataset):
 
     def __init__(
             self,
-            segment_number: Optional[int],
+            segment_number: int,
             segment_label: str,
             segmented_property_category: Union[Code, CodedConcept],
             segmented_property_type: Union[Code, CodedConcept],
@@ -43,11 +43,8 @@ class SegmentDescription(Dataset):
         """
         Parameters
         ----------
-        segment_number: Optional[int]
-            Number of the segment. If set to ``None``, no segment number will
-            assigned at this time, and a number will be automatically
-            determined when the description is added to a segmentation
-            instance.
+        segment_number: int
+            Number of the segment.
         segment_label: str
             Label of the segment
         segmented_property_category: Union[pydicom.sr.coding.Code, highdicom.sr.coding.CodedConcept]
@@ -79,12 +76,17 @@ class SegmentDescription(Dataset):
             Anatomic structure(s) the segment represents
             (see CIDs for domain-specific primary anatomic structures)
 
+        Notes
+        -----
+        When segment descriptions are passed to a segmentation instance they
+        must have consecutive segment numbers, starting at 1 for the first
+        segment added.
+
         """  # noqa
         super().__init__()
-        if segment_number is not None:
-            if segment_number < 1:
-                raise ValueError("Segment number must be a positive integer")
-            self.SegmentNumber = segment_number
+        if segment_number < 1:
+            raise ValueError("Segment number must be a positive integer")
+        self.SegmentNumber = segment_number
         self.SegmentLabel = segment_label
         self.SegmentedPropertyCategoryCodeSequence = [
             CodedConcept(

--- a/src/highdicom/seg/content.py
+++ b/src/highdicom/seg/content.py
@@ -23,11 +23,11 @@ class SegmentDescription(Dataset):
 
     def __init__(
             self,
-            segment_number: int,
             segment_label: str,
             segmented_property_category: Union[Code, CodedConcept],
             segmented_property_type: Union[Code, CodedConcept],
             algorithm_type: Union[SegmentAlgorithmTypeValues, str],
+            segment_number: Optional[int] = None,
             algorithm_identification: Optional[
                 AlgorithmIdentificationSequence
             ] = None,
@@ -78,7 +78,8 @@ class SegmentDescription(Dataset):
 
         """  # noqa
         super().__init__()
-        self.SegmentNumber = segment_number
+        if segment_number is not None:
+            self.SegmentNumber = segment_number
         self.SegmentLabel = segment_label
         self.SegmentedPropertyCategoryCodeSequence = [
             CodedConcept(

--- a/src/highdicom/seg/sop.py
+++ b/src/highdicom/seg/sop.py
@@ -579,7 +579,10 @@ class Segmentation(SOPClass):
                     # The appropriate error message depends on whether segment
                     # numbers were provided or automatically determined
                     if all(descriptions_are_numbered):
-                        msg = 'Pixel array contains segments that lack descriptions.'
+                        msg = (
+                            'Pixel array contains segments that lack '
+                            'descriptions.'
+                        )
                     else:
                         msg = (
                             'Pixel array contains integer values that are not '

--- a/src/highdicom/seg/sop.py
+++ b/src/highdicom/seg/sop.py
@@ -474,15 +474,55 @@ class Segmentation(SOPClass):
             Position of each plane in `pixel_array` relative to the
             three-dimensional patient or slide coordinate system.
 
+        Raises
+        ------
+        ValueError
+            When
+                - The pixel array is not 2D or 3D numpy array
+                - The shape of the pixel array does not match the source images
+                - The segment descriptions contain a mixture of numbered
+                  and unnumbered segments
+                - The segment descriptions are numbered and the numbering is
+                  not monotonically increasing by 1
+                - The segment descriptions are numbered and the numbering does
+                  not begin at 1 (for the first segments added to the instance)
+                  or at one greater than the last added segment (for
+                  subsequent segments)
+                - The segment descriptions are numbered and one or more
+                  segments already exist within the segmentation instance
+                - The segmentation is binary and the pixel array contains
+                  integer values that belong to segments that are not described
+                  in the segment descriptions
+                - The segmentation is binary and pixel array has floating point
+                  values not equal to 0.0 or 1.0
+                - The segmentation is fractional and pixel array has floating
+                  point values outside the range 0.0 to 1.0
+                - The segmentation is fractional and pixel array has floating
+                  point values outside the range 0.0 to 1.0
+                - Plane positions are provided but the length of the array
+                  does not match the number of frames in the pixel array
+        TypeError
+            When the dtype of the pixel array is invalid
+
+
         Note
         ----
-        Items of `segment_descriptions` must be sorted by segment number in
-        ascending order.
-        In case `segmentation_type` is ``"BINARY"``, the number of items per
-        sequence must match the number of unique positive pixel values in
+        Items of `segment_descriptions` may be either numbered or unnumbered
+        (constructed with ``segment_number=None``). If numbered, segments must
+        be sorted by segment number in ascending order and increase by 1.
+        Additionally, the first segment description must have a segment number
+        one greater than the segment number of the last segment added to the
+        segmentation, or 1 if this is the first segment added. If unnumbered,
+        segment numbers will be determined automatically following the above
+        rules.
+
+        In case `segmentation_type` is ``"BINARY"``, the number of items in
+        `segment_descriptions` must be greater than or equal to the number of
+        unique positive pixel values in `pixel_array`. It is possible for some
+        segments described in `segment_descriptions` not to appear in the
         `pixel_array`. In case `segmentation_type` is ``"FRACTIONAL"``, only
         one segment can be encoded by `pixel_array` and hence only one item is
-        permitted per sequence.
+        permitted in `segment_descriptions`.
 
         """  # noqa
         if pixel_array.ndim == 2:

--- a/tests/test_seg.py
+++ b/tests/test_seg.py
@@ -136,11 +136,11 @@ class TestSegmentDescription(unittest.TestCase):
 
     def test_construction(self):
         item = SegmentDescription(
+            self._segment_number,
             self._segment_label,
             self._segmented_property_category,
             self._segmented_property_type,
             self._segment_algorithm_type,
-            self._segment_number,
             self._algorithm_identification
         )
         assert item.SegmentNumber == self._segment_number
@@ -465,6 +465,7 @@ class TestSegmentation(unittest.TestCase):
         self._segmented_property_type = codes.SCT.Neoplasm
         self._segment_descriptions = [
             SegmentDescription(
+                segment_number=None,
                 segment_label='Segment #1',
                 segmented_property_category=self._segmented_property_category,
                 segmented_property_type=self._segmented_property_type,
@@ -478,11 +479,11 @@ class TestSegmentation(unittest.TestCase):
         ]
         self._segment_descriptions_numbered = [
             SegmentDescription(
+                segment_number=1,
                 segment_label='Segment #1',
                 segmented_property_category=self._segmented_property_category,
                 segmented_property_type=self._segmented_property_type,
                 algorithm_type=SegmentAlgorithmTypeValues.AUTOMATIC.value,
-                segment_number=1,
                 algorithm_identification=AlgorithmIdentificationSequence(
                     name='bla',
                     family=codes.DCM.ArtificialIntelligence,
@@ -492,6 +493,7 @@ class TestSegmentation(unittest.TestCase):
         ]
         self._additional_segment_descriptions = [
             SegmentDescription(
+                segment_number=None,
                 segment_label='Segment #2',
                 segmented_property_category=self._segmented_property_category,
                 segmented_property_type=self._segmented_property_type,
@@ -505,11 +507,11 @@ class TestSegmentation(unittest.TestCase):
         ]
         self._additional_segment_descriptions_numbered = [
             SegmentDescription(
+                segment_number=2,
                 segment_label='Segment #2',
                 segmented_property_category=self._segmented_property_category,
                 segmented_property_type=self._segmented_property_type,
                 algorithm_type=SegmentAlgorithmTypeValues.AUTOMATIC.value,
-                segment_number=2,
                 algorithm_identification=AlgorithmIdentificationSequence(
                     name='foo',
                     family=codes.DCM.ArtificialIntelligence,
@@ -519,11 +521,11 @@ class TestSegmentation(unittest.TestCase):
         ]
         self._additional_segment_descriptions_numbered_4 = [
             SegmentDescription(
+                segment_number=4,
                 segment_label='Segment #4',
                 segmented_property_category=self._segmented_property_category,
                 segmented_property_type=self._segmented_property_type,
                 algorithm_type=SegmentAlgorithmTypeValues.AUTOMATIC.value,
-                segment_number=4,
                 algorithm_identification=AlgorithmIdentificationSequence(
                     name='foo',
                     family=codes.DCM.ArtificialIntelligence,

--- a/tests/test_seg.py
+++ b/tests/test_seg.py
@@ -118,6 +118,7 @@ class TestSegmentDescription(unittest.TestCase):
     def setUp(self):
         super().setUp()
         self._segment_number = 1
+        self._invalid_segment_number = 0
         self._segment_label = 'segment #1'
         self._segmented_property_category = \
             codes.SCT.MorphologicallyAbnormalStructure
@@ -158,6 +159,17 @@ class TestSegmentDescription(unittest.TestCase):
             item.TrackingUID
             item.AnatomicRegionSequence
             item.PrimaryAnatomicStructureSequence
+
+    def test_construction_invalid_segment_number(self):
+        with pytest.raises(ValueError):
+            item = SegmentDescription(
+                self._invalid_segment_number,
+                self._segment_label,
+                self._segmented_property_category,
+                self._segmented_property_type,
+                self._segment_algorithm_type,
+                self._algorithm_identification
+            )
 
     def test_construction_missing_required_argument(self):
         with pytest.raises(TypeError):

--- a/tests/test_seg.py
+++ b/tests/test_seg.py
@@ -680,6 +680,7 @@ class TestSegmentation(unittest.TestCase):
             instance.LossyImageCompressionRatio
             instance.LossyImageCompressionMethod
         assert len(instance.SegmentSequence) == 1
+        assert instance.SegmentSequence[0].SegmentNumber == 1
         assert len(instance.SourceImageSequence) == 1
         assert len(instance.DimensionIndexSequence) == 2
         ref_item = instance.SourceImageSequence[0]
@@ -737,6 +738,7 @@ class TestSegmentation(unittest.TestCase):
         assert instance.SpecimenDescriptionSequence[0].SpecimenUID == \
             self._sm_image.SpecimenDescriptionSequence[0].SpecimenUID
         assert len(instance.SegmentSequence) == 1
+        assert instance.SegmentSequence[0].SegmentNumber == 1
         assert len(instance.SourceImageSequence) == 1
         ref_item = instance.SourceImageSequence[0]
         assert ref_item.ReferencedSOPInstanceUID == \
@@ -799,6 +801,7 @@ class TestSegmentation(unittest.TestCase):
         assert instance.PatientID == src_im.PatientID
         assert instance.AccessionNumber == src_im.AccessionNumber
         assert len(instance.SegmentSequence) == 1
+        assert instance.SegmentSequence[0].SegmentNumber == 1
         assert len(instance.SourceImageSequence) == len(self._ct_series)
         ref_item = instance.SourceImageSequence[1]
         assert ref_item.ReferencedSOPInstanceUID == src_im.SOPInstanceUID
@@ -867,6 +870,7 @@ class TestSegmentation(unittest.TestCase):
         assert instance.PatientID == self._ct_multiframe.PatientID
         assert instance.AccessionNumber == self._ct_multiframe.AccessionNumber
         assert len(instance.SegmentSequence) == 1
+        assert instance.SegmentSequence[0].SegmentNumber == 1
         assert len(instance.SourceImageSequence) == 1
         ref_item = instance.SourceImageSequence[0]
         assert ref_item.ReferencedSOPInstanceUID == \
@@ -1199,6 +1203,11 @@ class TestSegmentation(unittest.TestCase):
                 max_fractional_value=1
             )
 
+
+            assert len(instance.SegmentSequence) == 2
+            assert instance.SegmentSequence[0].SegmentNumber == 1
+            assert instance.SegmentSequence[1].SegmentNumber == 2
+
             # Ensure the recovered pixel array matches what is expected
             assert np.array_equal(
                 self.get_array_after_writing(instance),
@@ -1274,8 +1283,8 @@ class TestSegmentation(unittest.TestCase):
                 pixel_array=self._ct_pixel_array,
                 segmentation_type=SegmentationTypeValues.FRACTIONAL.value,
                 segment_descriptions=(
-                    self._additional_segment_descriptions_numbered +
-                    self._segment_descriptions_numbered
+                    self._additional_segment_descriptions_numbered +  # seg 2
+                    self._segment_descriptions_numbered               # seg 1
                 ),
                 series_instance_uid=self._series_instance_uid,
                 series_number=self._series_number,
@@ -1295,7 +1304,7 @@ class TestSegmentation(unittest.TestCase):
                 segmentation_type=SegmentationTypeValues.FRACTIONAL.value,
                 segment_descriptions=(
                     self._segment_descriptions_numbered +
-                    self._segment_descriptions_numbered
+                    self._segment_descriptions_numbered  # duplicate
                 ),
                 series_instance_uid=self._series_instance_uid,
                 series_number=self._series_number,
@@ -1316,7 +1325,7 @@ class TestSegmentation(unittest.TestCase):
                 segment_descriptions=(
                     self._segment_descriptions_numbered +
                     self._additional_segment_descriptions_numbered
-                ),
+                ),  # two segments, value of 3 in pixel array
                 series_instance_uid=self._series_instance_uid,
                 series_number=self._series_number,
                 sop_instance_uid=self._sop_instance_uid,

--- a/tests/test_seg.py
+++ b/tests/test_seg.py
@@ -477,20 +477,6 @@ class TestSegmentation(unittest.TestCase):
         self._segmented_property_type = codes.SCT.Neoplasm
         self._segment_descriptions = [
             SegmentDescription(
-                segment_number=None,
-                segment_label='Segment #1',
-                segmented_property_category=self._segmented_property_category,
-                segmented_property_type=self._segmented_property_type,
-                algorithm_type=SegmentAlgorithmTypeValues.AUTOMATIC.value,
-                algorithm_identification=AlgorithmIdentificationSequence(
-                    name='bla',
-                    family=codes.DCM.ArtificialIntelligence,
-                    version='v1'
-                )
-            ),
-        ]
-        self._segment_descriptions_numbered = [
-            SegmentDescription(
                 segment_number=1,
                 segment_label='Segment #1',
                 segmented_property_category=self._segmented_property_category,
@@ -505,20 +491,6 @@ class TestSegmentation(unittest.TestCase):
         ]
         self._additional_segment_descriptions = [
             SegmentDescription(
-                segment_number=None,
-                segment_label='Segment #2',
-                segmented_property_category=self._segmented_property_category,
-                segmented_property_type=self._segmented_property_type,
-                algorithm_type=SegmentAlgorithmTypeValues.AUTOMATIC.value,
-                algorithm_identification=AlgorithmIdentificationSequence(
-                    name='foo',
-                    family=codes.DCM.ArtificialIntelligence,
-                    version='v1'
-                )
-            ),
-        ]
-        self._additional_segment_descriptions_numbered = [
-            SegmentDescription(
                 segment_number=2,
                 segment_label='Segment #2',
                 segmented_property_category=self._segmented_property_category,
@@ -531,7 +503,7 @@ class TestSegmentation(unittest.TestCase):
                 )
             ),
         ]
-        self._additional_segment_descriptions_numbered_4 = [
+        self._additional_segment_descriptions_no4 = [
             SegmentDescription(
                 segment_number=4,
                 segment_label='Segment #4',
@@ -1213,26 +1185,6 @@ class TestSegmentation(unittest.TestCase):
                 expected_encoding
             )
 
-    def test_construction_numbered_mismatch(self):
-        with pytest.raises(ValueError):
-            Segmentation(
-                source_images=[self._ct_image],
-                pixel_array=self._ct_pixel_array,
-                segmentation_type=SegmentationTypeValues.FRACTIONAL.value,
-                segment_descriptions=(
-                    self._segment_descriptions_numbered +  # numbered
-                    self._additional_segment_descriptions  # not numbered
-                ),
-                series_instance_uid=self._series_instance_uid,
-                series_number=self._series_number,
-                sop_instance_uid=self._sop_instance_uid,
-                instance_number=self._instance_number,
-                manufacturer=self._manufacturer,
-                manufacturer_model_name=self._manufacturer_model_name,
-                software_versions=self._software_versions,
-                device_serial_number=self._device_serial_number
-            )
-
     def test_construction_segment_numbers_start_wrong(self):
         with pytest.raises(ValueError):
             Segmentation(
@@ -1240,7 +1192,7 @@ class TestSegmentation(unittest.TestCase):
                 pixel_array=self._ct_pixel_array,
                 segmentation_type=SegmentationTypeValues.FRACTIONAL.value,
                 segment_descriptions=(
-                    self._additional_segment_descriptions_numbered  # seg num 2
+                    self._additional_segment_descriptions  # seg num 2
                 ),
                 series_instance_uid=self._series_instance_uid,
                 series_number=self._series_number,
@@ -1258,7 +1210,7 @@ class TestSegmentation(unittest.TestCase):
             pixel_array=self._ct_pixel_array,
             segmentation_type=SegmentationTypeValues.FRACTIONAL.value,
             segment_descriptions=(
-                self._segment_descriptions_numbered  # seg num 1
+                self._segment_descriptions  # seg num 1
             ),
             series_instance_uid=self._series_instance_uid,
             series_number=self._series_number,
@@ -1272,7 +1224,7 @@ class TestSegmentation(unittest.TestCase):
         with pytest.raises(ValueError):
             instance.add_segments(
                 self._ct_pixel_array,
-                self._additional_segment_descriptions_numbered_4
+                self._additional_segment_descriptions_no4
             )
 
     def test_construction_wrong_segment_order(self):
@@ -1282,8 +1234,8 @@ class TestSegmentation(unittest.TestCase):
                 pixel_array=self._ct_pixel_array,
                 segmentation_type=SegmentationTypeValues.FRACTIONAL.value,
                 segment_descriptions=(
-                    self._additional_segment_descriptions_numbered +  # seg 2
-                    self._segment_descriptions_numbered               # seg 1
+                    self._additional_segment_descriptions +  # seg 2
+                    self._segment_descriptions               # seg 1
                 ),
                 series_instance_uid=self._series_instance_uid,
                 series_number=self._series_number,
@@ -1302,8 +1254,8 @@ class TestSegmentation(unittest.TestCase):
                 pixel_array=self._ct_pixel_array,
                 segmentation_type=SegmentationTypeValues.FRACTIONAL.value,
                 segment_descriptions=(
-                    self._segment_descriptions_numbered +
-                    self._segment_descriptions_numbered  # duplicate
+                    self._segment_descriptions +
+                    self._segment_descriptions  # duplicate
                 ),
                 series_instance_uid=self._series_instance_uid,
                 series_number=self._series_number,
@@ -1322,8 +1274,8 @@ class TestSegmentation(unittest.TestCase):
                 pixel_array=(self._ct_pixel_array * 3).astype(np.uint8),
                 segmentation_type=SegmentationTypeValues.FRACTIONAL.value,
                 segment_descriptions=(
-                    self._segment_descriptions_numbered +
-                    self._additional_segment_descriptions_numbered
+                    self._segment_descriptions +
+                    self._additional_segment_descriptions
                 ),  # two segments, value of 3 in pixel array
                 series_instance_uid=self._series_instance_uid,
                 series_number=self._series_number,

--- a/tests/test_seg.py
+++ b/tests/test_seg.py
@@ -162,7 +162,7 @@ class TestSegmentDescription(unittest.TestCase):
 
     def test_construction_invalid_segment_number(self):
         with pytest.raises(ValueError):
-            item = SegmentDescription(
+            SegmentDescription(
                 self._invalid_segment_number,
                 self._segment_label,
                 self._segmented_property_category,
@@ -1202,7 +1202,6 @@ class TestSegmentation(unittest.TestCase):
                 self._device_serial_number,
                 max_fractional_value=1
             )
-
 
             assert len(instance.SegmentSequence) == 2
             assert instance.SegmentSequence[0].SegmentNumber == 1


### PR DESCRIPTION
I was recently reading the standard and realised that highdicom is currently too leniant in what it allows for valid segment numbers. The [standard](http://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_C.8.20.2.4.html#sect_C.8.20.2.4) states:

> Segment Number (0062,0004) shall be unique within each Instance, start at a value of 1, and increase monotonically by 1

As a result, if the segmentation instance is to be valid at all points after its construction, the segments must be added in strict ascending order (1, 2, 3, 4, 5, ....).

Currently we enforce that segment numbers are unique and sorted within a given `add_segments` call but all the following invalid possibilities can currently happen:
- Segment numbers that are negative
- Segment numbers equal to zero (this is actually very likely to happen in practice, with python programmers used to zero-based indexing. In fact this is how I noticed this issue and opened pandora's box)
- Segment numbers that are sorted but not consecutive (e.g. `[1, 2, 45, 126]`)
- Segment numbers that over the course of multiple calls to `add_segments` give rise to an unsorted list. E.g. it currently possible to call with a segment number 2 and then later with segment number 1, giving rise to an invalid segmentation instance.

Any one of these would give rise to non-compliant segmentation instances produced by highdicom, so fixing this should be fairly high priority.

In this PR, I have added checks to enforce that all of the above situations are now disallowed and raise errors with hopefully useful error messages. I have added appropriate documentation and tests.

Given that the standard is so prescriptive in how segment numbers are used, I am questioning whether it makes sense to make the user specify the segment numbers manually in the segment descriptions in most situations. I imagine that >95% of uses of the segmentation instance will fall into one of the following two cases:
- A single call to the constructor with single or multiple segments in the pixel array
- A call to the constructor with a single segment, followed by subsequent calls to the `add_segments` method, each with a single additional segment.

In other words, multiple calls to `add_segments` each with multiple segments is a situation that I imagine will only arise very seldomly.

In both of the common cases, having the user specify the segment numbers manually is arguably just boilerplate and a possibility for annoying errors to occur. Therefore in this PR I am suggesting the following: that the segment_number argument to SegmentDescription now accepts `None` value. In this case `add_segments` will automatically determine the segment numbers such that they occur in the correct pattern. In time, I would suggest that the `segment_number` argument is moved to be an optional argument to `SegmentDescription`, but this is a breaking change that we may want to be more careful about.

Alternatively, if you prefer, we have two other options:
- Make `segment_number` an optional parameter in this PR (breaking change)
- Continue to require `segment_number` to be explicitly specified by the user and accept that this is boilerplate in most cases.

Thoughts?
 