### PR TITLE
Add function to correctly format a DS string

### DIFF
--- a/docs/package.rst
+++ b/docs/package.rst
@@ -77,6 +77,14 @@ highdicom.utils module
    :undoc-members:
    :show-inheritance:
 
+highdicom.valuerep module
++++++++++++++++++++++++++
+
+.. automodule:: highdicom.valuerep
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 
 .. _highdicom-legacy-subpackage:
 

--- a/src/highdicom/content.py
+++ b/src/highdicom/content.py
@@ -12,6 +12,7 @@ from highdicom.enum import (
     CoordinateSystemNames,
     UniversalEntityIDTypeValues,
 )
+from highdicom.valuerep import get_ds_string
 from highdicom.sr.coding import CodedConcept
 from highdicom.sr.value_types import (
     CodeContentItem,
@@ -103,10 +104,10 @@ class PixelMeasuresSequence(DataElementSequence):
         """
         super().__init__()
         item = Dataset()
-        item.PixelSpacing = list(pixel_spacing)
-        item.SliceThickness = slice_thickness
+        item.PixelSpacing = [get_ds_string(ps) for ps in pixel_spacing]
+        item.SliceThickness = get_ds_string(slice_thickness)
         if spacing_between_slices is not None:
-            item.SpacingBetweenSlices = spacing_between_slices
+            item.SpacingBetweenSlices = get_ds_string(spacing_between_slices)
         self.append(item)
 
 
@@ -145,9 +146,6 @@ class PlanePositionSequence(DataElementSequence):
         super().__init__()
         item = Dataset()
 
-        def ds(num: float) -> float:
-            return float(str(num)[:16])
-
         coordinate_system = CoordinateSystemNames(coordinate_system)
         if coordinate_system == CoordinateSystemNames.SLIDE:
             if pixel_matrix_position is None:
@@ -157,13 +155,15 @@ class PlanePositionSequence(DataElementSequence):
                 )
             col_position, row_position = pixel_matrix_position
             x, y, z = image_position
-            item.XOffsetInSlideCoordinateSystem = ds(x)
-            item.YOffsetInSlideCoordinateSystem = ds(y)
-            item.ZOffsetInSlideCoordinateSystem = ds(z)
+            item.XOffsetInSlideCoordinateSystem = get_ds_string(x)
+            item.YOffsetInSlideCoordinateSystem = get_ds_string(y)
+            item.ZOffsetInSlideCoordinateSystem = get_ds_string(z)
             item.RowPositionInTotalImagePixelMatrix = row_position
             item.ColumnPositionInTotalImagePixelMatrix = col_position
         elif coordinate_system == CoordinateSystemNames.PATIENT:
-            item.ImagePositionPatient = list(image_position)
+            item.ImagePositionPatient = [
+                get_ds_string(p) for p in image_position
+            ]
         else:
             raise ValueError(
                 f'Unknown coordinate system "{coordinate_system.value}".'
@@ -241,9 +241,13 @@ class PlaneOrientationSequence(DataElementSequence):
         item = Dataset()
         coordinate_system = CoordinateSystemNames(coordinate_system)
         if coordinate_system == CoordinateSystemNames.SLIDE:
-            item.ImageOrientationSlide = list(image_orientation)
+            item.ImageOrientationSlide = [
+                get_ds_string(e) for e in image_orientation
+            ]
         elif coordinate_system == CoordinateSystemNames.PATIENT:
-            item.ImageOrientationPatient = list(image_orientation)
+            item.ImageOrientationPatient = [
+                get_ds_string(e) for e in image_orientation
+            ]
         else:
             raise ValueError(
                 f'Unknown coordinate system "{coordinate_system.value}".'
@@ -261,7 +265,7 @@ class PlaneOrientationSequence(DataElementSequence):
         Returns
         -------
         bool
-            Whether the two image planes have the same orientation
+            Whether the two image planes ha[
 
         """
         if not isinstance(other, self.__class__):

--- a/src/highdicom/content.py
+++ b/src/highdicom/content.py
@@ -265,7 +265,7 @@ class PlaneOrientationSequence(DataElementSequence):
         Returns
         -------
         bool
-            Whether the two image planes ha[
+            Whether the two image planes have the same orientation
 
         """
         if not isinstance(other, self.__class__):

--- a/src/highdicom/sr/value_types.py
+++ b/src/highdicom/sr/value_types.py
@@ -9,6 +9,7 @@ from pydicom.sr.coding import Code
 from pydicom.uid import UID
 from pydicom.valuerep import DA, TM, DT, PersonName
 
+from highdicom.valuerep import get_ds_string
 from highdicom.sr.coding import CodedConcept
 from highdicom.sr.enum import (
     GraphicTypeValues,
@@ -426,7 +427,7 @@ class NumContentItem(ContentItem):
                 raise TypeError(
                     'Argument "value" must have type "int" or "float".'
                 )
-            measured_value_sequence_item.NumericValue = value
+            measured_value_sequence_item.NumericValue = get_ds_string(value)
             if isinstance(value, float):
                 measured_value_sequence_item.FloatingPointValue = value
             if not isinstance(unit, (CodedConcept, Code, )):
@@ -801,7 +802,7 @@ class TcoordContentItem(ContentItem):
             ]
         elif referenced_time_offsets is not None:
             self.ReferencedTimeOffsets = [
-                float(v) for v in referenced_time_offsets
+                get_ds_string(float(v)) for v in referenced_time_offsets
             ]
         elif referenced_date_time is not None:
             self.ReferencedDateTime = [

--- a/src/highdicom/valuerep.py
+++ b/src/highdicom/valuerep.py
@@ -1,0 +1,68 @@
+from math import log10, floor
+
+from numpy import isfinite
+
+
+def get_ds_string(f: float) -> str:
+    """Get a string representation of a float suitable for DS value types
+
+    Returns a string representation of a floating point number that follows
+    the constraints that apply to decimal strings (DS) value representations.
+    These include that the string must be a maximum of 16 characters and
+    contain only digits, and '+', '-', '.' and 'e' characters.
+
+    Parameters
+    ----------
+    f: float
+        Floating point number whose string representation is required
+
+    Returns
+    -------
+    str:
+        String representation of f, following the decimal string constraints
+
+    Raises
+    ------
+    ValueError:
+        If the float is not representable as a decimal string (for example
+        because it has value ``nan`` or ``inf``)
+
+    """
+    if not isfinite(f):
+        raise ValueError(
+            "Cannot encode non-finite floats as DICOM decimal strings. "
+            f"Got {f}"
+        )
+
+    fstr = str(f)
+    # In the simple case, the built-in python string representation
+    # will do
+    if len(fstr) <= 16:
+        return fstr
+
+    # Decide whether to use scientific notation
+    # (follow convention of python's standard float to string conversion)
+    logf = log10(abs(f))
+    use_scientific = logf < -4 or logf >= 13
+
+    # Characters needed for '-' at start
+    sign_chars = 1 if f < 0.0 else 0
+
+    if use_scientific:
+        # How many chars are taken by the exponent at the end
+        # In principle could have number where the exponent
+        # needs three digits to represent (bigger cannot be
+        # represented by float)
+        if logf >= 100 or logf <= -100:
+            exp_chars = 5  # e.g. 'e-123'
+        else:
+            exp_chars = 4  # e.g. 'e+08'
+        remaining_chars = 14 - sign_chars - exp_chars
+        return f'%.{remaining_chars}e' % f
+    else:
+        if logf >= 1.0:
+            # chars remaining for digits after sign, digits left of '.' and '.'
+            remaining_chars = 14 - sign_chars - int(floor(logf))
+        else:
+            remaining_chars = 14 - sign_chars
+        return f'%.{remaining_chars}f' % f

--- a/src/highdicom/valuerep.py
+++ b/src/highdicom/valuerep.py
@@ -49,10 +49,10 @@ def get_ds_string(f: float) -> str:
     sign_chars = 1 if f < 0.0 else 0
 
     if use_scientific:
-        # How many chars are taken by the exponent at the end
-        # In principle could have number where the exponent
-        # needs three digits to represent (bigger cannot be
-        # represented by float)
+        # How many chars are taken by the exponent at the end.
+        # In principle, we could have number where the exponent
+        # needs three digits represent (bigger than this cannot be
+        # represented by floats)
         if logf >= 100 or logf <= -100:
             exp_chars = 5  # e.g. 'e-123'
         else:

--- a/tests/test_valuerep.py
+++ b/tests/test_valuerep.py
@@ -1,0 +1,36 @@
+import pytest
+
+from highdicom.valuerep import get_ds_string
+
+
+@pytest.mark.parametrize(
+    "float_val,expected_str",
+    [
+        [1.0, "1.0"],
+        [0.0, "0.0"],
+        [-0.0, "-0.0"],
+        [0.123, "0.123"],
+        [-0.321, "-0.321"],
+        [0.00001, "1e-05"],
+        [3.14159265358979323846, '3.14159265358979'],
+        [-3.14159265358979323846, '-3.1415926535898'],
+        [5.3859401928763739403e-7, '5.3859401929e-07'],
+        [-5.3859401928763739403e-7, '-5.385940193e-07'],
+        [1.2342534378125532912998323e10, '12342534378.1255'],
+        [6.40708699858767842501238e13, '6.4070869986e+13'],
+        [1.7976931348623157e+308, '1.797693135e+308'],
+    ]
+)
+def test_get_ds_string(float_val: float, expected_str: str):
+    returned_str = get_ds_string(float_val)
+    assert len(returned_str) <= 16
+    assert expected_str == returned_str
+
+
+@pytest.mark.parametrize(
+    'float_val',
+    [float('nan'), float('inf'), float('-nan'), float('-inf')]
+)
+def test_get_ds_string_invalid(float_val: float):
+    with pytest.raises(ValueError):
+        get_ds_string(float_val)


### PR DESCRIPTION
According to the standard, attributes with the decimal string (DS) value representation must contain a maximum of 16 characters (see [here](http://dicom.nema.org/medical/dicom/current/output/chtml/part05/sect_6.2.html)). Unfortunately pydicom does not enforce this, and it looks like there is no movement on @hackermd's [open issue](https://github.com/pydicom/pydicom/issues/1264) to rectify this.

A quick fix was previously implemented in the `PlanePositionSequence`, but this was sub-optimal as it truncated (rather than correctly rounding) and did not handle certain cases correctly (e.g. values that python would write in scientific notation when calling the str() method on a float).

Furthermore, there are several other instances around the codebase where this fix was not implemented, meaning that invalid DS could be created. For example in NumContentItem, which is used for recording nearly all numeric values in an SR document. I found that this was causing many SRs I created to fail the checks in the dciodvfy tool.

This PR implements a new function that I believe correctly handles all edge cases, and rounds properly. It also checks for nans/infs, which would previously be silently stored as strings despite being invalid values for DS. Also added tests and docs.

I have tried to find all the places in the codebase where DS elements are created and switch to using the new function, but I'm not 100% sure I found that I found them all.