### PR TITLE
Prevent empty content sequence in Finding Site

### DIFF
--- a/src/highdicom/sr/content.py
+++ b/src/highdicom/sr/content.py
@@ -447,29 +447,30 @@ class FindingSite(CodeContentItem):
             value=anatomic_location,
             relationship_type=RelationshipTypeValues.HAS_CONCEPT_MOD
         )
-        self.ContentSequence = ContentSequence()
-        if laterality is not None:
-            laterality_item = CodeContentItem(
-                name=CodedConcept(
-                    value='272741003',
-                    meaning='Laterality',
-                    scheme_designator='SCT'
-                ),
-                value=laterality,
-                relationship_type=RelationshipTypeValues.HAS_CONCEPT_MOD
-            )
-            self.ContentSequence.append(laterality_item)
-        if topographical_modifier is not None:
-            modifier_item = CodeContentItem(
-                name=CodedConcept(
-                    value='106233006',
-                    meaning='Topographical Modifier',
-                    scheme_designator='SCT'
-                ),
-                value=topographical_modifier,
-                relationship_type=RelationshipTypeValues.HAS_CONCEPT_MOD
-            )
-            self.ContentSequence.append(modifier_item)
+        if laterality is not None or topographical_modifier is not None:
+            self.ContentSequence = ContentSequence()
+            if laterality is not None:
+                laterality_item = CodeContentItem(
+                    name=CodedConcept(
+                        value='272741003',
+                        meaning='Laterality',
+                        scheme_designator='SCT'
+                    ),
+                    value=laterality,
+                    relationship_type=RelationshipTypeValues.HAS_CONCEPT_MOD
+                )
+                self.ContentSequence.append(laterality_item)
+            if topographical_modifier is not None:
+                modifier_item = CodeContentItem(
+                    name=CodedConcept(
+                        value='106233006',
+                        meaning='Topographical Modifier',
+                        scheme_designator='SCT'
+                    ),
+                    value=topographical_modifier,
+                    relationship_type=RelationshipTypeValues.HAS_CONCEPT_MOD
+                )
+                self.ContentSequence.append(modifier_item)
 
 
 class ReferencedSegmentationFrame(ContentSequence):

--- a/tests/test_sr.py
+++ b/tests/test_sr.py
@@ -816,7 +816,7 @@ class TestFindingSite(unittest.TestCase):
         item = self._finding_site
         assert item.ConceptNameCodeSequence[0].CodeValue == '363698007'
         assert item.ConceptCodeSequence[0] == self._location
-        assert len(item.ContentSequence) == 0
+        assert not hasattr(item, 'ContentSequence')
 
 
 class TestTrackingIdentifierOptional(unittest.TestCase):
@@ -963,7 +963,7 @@ class TestMeasurementOptional(unittest.TestCase):
         assert item.ConceptNameCodeSequence[0].CodeValue == '363698007'
         assert item.ConceptCodeSequence[0] == self._location
         # Laterality and topological modifier were not specified
-        assert len(item.ContentSequence) == 0
+        assert not hasattr(item, 'ContentSequence')
 
 
 class TestImageRegion(unittest.TestCase):


### PR DESCRIPTION
If a FindingSite object is constructed with neither optional parameter specified (`laterality=None` and `topographical_modifier=None`), the item will be constructed with an empty `ContentSequence` (i.e. a sequence of length 0).

However, `ContentSequence` is a type 1C attribute, which I believe means that it cannot be empty. Further more [table C.17-6](http://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_C.17.3.html#table_C.17-6) states explicitly that

> One or more Items shall be included in this Sequence

I conclude that the expected behaviour in this situation is that the `ContentSequence` attribute should not be present. I was previously encountering (somewhat crytic) errors with dciodvfy before implementing this fix, and these have now gone.