### PR TITLE
Add test fixture to enable enforce_valid_values flag in pydicom

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+import pytest
+
+from pydicom import config
+
+
+@pytest.fixture(autouse=True, scope='session')
+def setup_pydicom_config():
+    """Fixture that sets up pydicom config values for all tests."""
+    config.enforce_valid_values = True
+    yield


### PR DESCRIPTION
Added a pytest fixture that is run before all tests are performed and sets pydicom's `enforce_valid_values` to `True` for the entire test session.

This should help catch potential errors. Currently all tests still pass because pydicom internally does not catch certain errors (such as float truncation errors). However hopefully this will improve in the future.

Inspired by conversation in #56.