### PR TITLE
Integrate new pydicom DS formatting

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setuptools.setup(
     package_dir={'': 'src'},
     python_requires='>=3.6',
     install_requires=[
-        'pydicom>=1.4,!=2.1.0,!=2.1.1',
+        'pydicom>=2.2.0',
         'numpy>=1.19',
         'pillow>=6.0'
     ],

--- a/src/highdicom/sr/value_types.py
+++ b/src/highdicom/sr/value_types.py
@@ -7,7 +7,7 @@ from pydicom.dataset import Dataset
 from pydicom.sequence import Sequence as DataElementSequence
 from pydicom.sr.coding import Code
 from pydicom.uid import UID
-from pydicom.valuerep import DA, TM, DT, PersonName
+from pydicom.valuerep import DA, DS, TM, DT, PersonName
 
 from highdicom.sr.coding import CodedConcept
 from highdicom.sr.enum import (
@@ -426,7 +426,10 @@ class NumContentItem(ContentItem):
                 raise TypeError(
                     'Argument "value" must have type "int" or "float".'
                 )
-            measured_value_sequence_item.NumericValue = value
+            measured_value_sequence_item.NumericValue = DS(
+                value,
+                auto_format=True
+            )
             if isinstance(value, float):
                 measured_value_sequence_item.FloatingPointValue = value
             if not isinstance(unit, (CodedConcept, Code, )):
@@ -801,7 +804,7 @@ class TcoordContentItem(ContentItem):
             ]
         elif referenced_time_offsets is not None:
             self.ReferencedTimeOffsets = [
-                float(v) for v in referenced_time_offsets
+                DS(v, auto_format=True) for v in referenced_time_offsets
             ]
         elif referenced_date_time is not None:
             self.ReferencedDateTime = [


### PR DESCRIPTION
As noted in #57, highdicom currently produces datasets with invalid decimal strings in many situations. The functionality to correctly format DSs is now integrated into pydicom, see https://github.com/pydicom/pydicom/pull/1334.

This PR integrates this behaviour into highdicom wherever it sets a value for a DS attribute.

**Important** this depends upon behaviour on pydicom master branch that will be in the next release of pydicom, which will be 2.2.0. I have updated `setup.py` to reflect this. This PR should *not* be merged until such a time that pydicom 2.2.0 is released and available on pypi. Tests will also fail until that time, but they do pass on my local machine when I have pydicom installed from master branch.