### PR TITLE
Spatial Transformer documentation

### DIFF
--- a/docs/package.rst
+++ b/docs/package.rst
@@ -165,7 +165,7 @@ highdicom.sr package
    :members:
    :special-members: __call__
    :undoc-members:
-   :show-inheritance
+   :show-inheritance:
 
 highdicom.sr.coding module
 ++++++++++++++++++++++++++

--- a/docs/package.rst
+++ b/docs/package.rst
@@ -10,6 +10,7 @@ highdicom package
 
 .. automodule:: highdicom
    :members:
+   :special-members: __call__
    :undoc-members:
    :show-inheritance:
 
@@ -18,6 +19,7 @@ highdicom.color module
 
 .. automodule:: highdicom.color
    :members:
+   :special-members: __call__
    :undoc-members:
    :show-inheritance:
 
@@ -26,6 +28,7 @@ highdicom.content module
 
 .. automodule:: highdicom.content
    :members:
+   :special-members: __call__
    :undoc-members:
    :show-inheritance:
 
@@ -34,6 +37,7 @@ highdicom.enum module
 
 .. automodule:: highdicom.enum
    :members:
+   :special-members: __call__
    :undoc-members:
    :show-inheritance:
 
@@ -42,6 +46,7 @@ highdicom.frame module
 
 .. automodule:: highdicom.frame
    :members:
+   :special-members: __call__
    :undoc-members:
    :show-inheritance:
 
@@ -50,6 +55,7 @@ highdicom.io module
 
 .. automodule:: highdicom.io
    :members:
+   :special-members: __call__
    :undoc-members:
    :show-inheritance:
 
@@ -58,6 +64,7 @@ highdicom.spatial module
 
 .. automodule:: highdicom.spatial
    :members:
+   :special-members: __call__
    :undoc-members:
    :show-inheritance:
 
@@ -66,6 +73,7 @@ highdicom.uid module
 
 .. automodule:: highdicom.uid
    :members:
+   :special-members: __call__
    :undoc-members:
    :show-inheritance:
 
@@ -74,6 +82,7 @@ highdicom.utils module
 
 .. automodule:: highdicom.utils
    :members:
+   :special-members: __call__
    :undoc-members:
    :show-inheritance:
 
@@ -85,6 +94,7 @@ highdicom.legacy package
 
 .. automodule:: highdicom.legacy
    :members:
+   :special-members: __call__
    :undoc-members:
    :show-inheritance:
 
@@ -94,6 +104,7 @@ highdicom.legacy.sop module
 
 .. automodule:: highdicom.legacy.sop
    :members:
+   :special-members: __call__
    :undoc-members:
    :show-inheritance:
 
@@ -105,6 +116,7 @@ highdicom.seg package
 
 .. automodule:: highdicom.seg
    :members:
+   :special-members: __call__
    :undoc-members:
    :show-inheritance:
 
@@ -113,6 +125,7 @@ highdicom.seg.content module
 
 .. automodule:: highdicom.seg.content
    :members:
+   :special-members: __call__
    :undoc-members:
    :show-inheritance:
 
@@ -121,6 +134,7 @@ highdicom.seg.enum module
 
 .. automodule:: highdicom.seg.enum
    :members:
+   :special-members: __call__
    :undoc-members:
    :show-inheritance:
 
@@ -129,6 +143,7 @@ highdicom.seg.sop module
 
 .. automodule:: highdicom.seg.sop
    :members:
+   :special-members: __call__
    :undoc-members:
    :show-inheritance:
 
@@ -137,6 +152,7 @@ highdicom.seg.utils module
 
 .. automodule:: highdicom.seg.utils
    :members:
+   :special-members: __call__
    :undoc-members:
    :show-inheritance:
 
@@ -147,14 +163,16 @@ highdicom.sr package
 
 .. automodule:: highdicom.sr
    :members:
+   :special-members: __call__
    :undoc-members:
-   :show-inheritance:
+   :show-inheritance
 
 highdicom.sr.coding module
 ++++++++++++++++++++++++++
 
 .. automodule:: highdicom.sr.coding
    :members:
+   :special-members: __call__
    :undoc-members:
    :show-inheritance:
 
@@ -163,6 +181,7 @@ highdicom.sr.content module
 
 .. automodule:: highdicom.sr.content
    :members:
+   :special-members: __call__
    :undoc-members:
    :show-inheritance:
 
@@ -171,6 +190,7 @@ highdicom.sr.enum module
 
 .. automodule:: highdicom.sr.enum
    :members:
+   :special-members: __call__
    :undoc-members:
    :show-inheritance:
 
@@ -179,6 +199,7 @@ highdicom.sr.sop module
 
 .. automodule:: highdicom.sr.sop
    :members:
+   :special-members: __call__
    :undoc-members:
    :show-inheritance:
 
@@ -187,6 +208,7 @@ highdicom.sr.utils module
 
 .. automodule:: highdicom.sr.utils
    :members:
+   :special-members: __call__
    :undoc-members:
    :show-inheritance:
 
@@ -195,6 +217,7 @@ highdicom.sr.templates module
 
 .. automodule:: highdicom.sr.templates
    :members:
+   :special-members: __call__
    :undoc-members:
    :show-inheritance:
 
@@ -203,6 +226,7 @@ highdicom.sr.value\_types module
 
 .. automodule:: highdicom.sr.value_types
    :members:
+   :special-members: __call__
    :undoc-members:
    :show-inheritance:
 
@@ -214,6 +238,7 @@ highdicom.sc package
 
 .. automodule:: highdicom.sc
    :members:
+   :special-members: __call__
    :undoc-members:
    :show-inheritance:
 
@@ -222,6 +247,7 @@ highdicom.sc.enum module
 
 .. automodule:: highdicom.sc.enum
    :members:
+   :special-members: __call__
    :undoc-members:
    :show-inheritance:
 
@@ -230,5 +256,6 @@ highdicom.sc.sop module
 
 .. automodule:: highdicom.sc.sop
    :members:
+   :special-members: __call__
    :undoc-members:
    :show-inheritance:

--- a/src/highdicom/spatial.py
+++ b/src/highdicom/spatial.py
@@ -42,6 +42,25 @@ class ImageToReferenceTransformer(object):
     Builds an affine transformation matrix for mapping two dimensional
     pixel matrix coordinates into the three dimensional frame of reference.
 
+    Examples
+    --------
+
+    >>> # Create a transformer by specifying the reference space of
+    >>> # an image
+    >>> transformer = ImageToReferenceTransformer(
+    >>>     image_position=[56.0, 34.2, 1.0],
+    >>>     image_orientation=[1.0, 0.0, 0.0, 0.0, 1.0, 0.0],
+    >>>     pixel_spacing=[0.5, 0.5]
+    >>> )
+    >>>
+    >>> # Use the transformer to convert coordinates
+    >>> image_coords = np.array([[0.0, 10.0], [5.0, 5.0]])
+    >>> ref_coords = transformer(image_coords)
+    >>>
+    >>> print(ref_coords)
+    >>> # [[56.  39.2  1. ]
+    >>> #  [58.5 36.7  1. ]]
+
     """
 
     def __init__(
@@ -174,6 +193,25 @@ class ReferenceToImageTransformer(object):
     Builds an affine transformation matrix for mapping coordinates in the
     three dimensional frame of reference into two-dimensional pixel matrix
     coordinates.
+
+    Examples
+    --------
+
+    >>> # Create a transformer by specifying the reference space of
+    >>> # an image
+    >>> transformer = ReferenceToImageTransformer(
+    >>>     image_position=[56.0, 34.2, 1.0],
+    >>>     image_orientation=[1.0, 0.0, 0.0, 0.0, 1.0, 0.0],
+    >>>     pixel_spacing=[0.5, 0.5]
+    >>> )
+    >>>
+    >>> # Use the transformer to convert coordinates
+    >>> ref_coords = np.array([[56., 39.2,  1. ], [58.5, 36.7, 1.]])
+    >>> image_coords = transformer(ref_coords)
+    >>>
+    >>> print(image_coords)
+    >>> # [[ 0. 10.  0.]
+    >>> #  [ 5.  5.  0.]]
 
     """
 


### PR DESCRIPTION
Currently the [documentation](https://highdicom.readthedocs.io/en/latest/package.html#highdicom.spatial.ImageToReferenceTransformer) for the `ImageToReferenceTransformer` and `ReferenceToImageTransformer` classes in `highdicom.spatial` do not make it clear how to actually apply the transform when constructed. This is largely due to the fact that the `__call__` special method is not included in the generated docs by sphinx by default. Even I had to actually refer to the source code to figure it out.

To address this issue, I have updated the doc packages to include `__call__` on classes in all packages. This only affects the above classes for now, but may affect others in the future potentially.

Additionally, for added clarity, I also added a small usage example to both classes. 