### PR TITLE
Fix import PR docstrings

### DIFF
--- a/docs/package.rst
+++ b/docs/package.rst
@@ -23,15 +23,6 @@ highdicom.color module
    :undoc-members:
    :show-inheritance:
 
-highdicom.content module
-++++++++++++++++++++++++
-
-.. automodule:: highdicom.content
-   :members:
-   :special-members: __call__
-   :undoc-members:
-   :show-inheritance:
-
 highdicom.enum module
 +++++++++++++++++++++
 
@@ -68,15 +59,6 @@ highdicom.spatial module
    :undoc-members:
    :show-inheritance:
 
-highdicom.uid module
-++++++++++++++++++++++
-
-.. automodule:: highdicom.uid
-   :members:
-   :special-members: __call__
-   :undoc-members:
-   :show-inheritance:
-
 highdicom.utils module
 ++++++++++++++++++++++
 
@@ -99,49 +81,12 @@ highdicom.legacy package
    :show-inheritance:
 
 
-highdicom.legacy.sop module
-+++++++++++++++++++++++++++
-
-.. automodule:: highdicom.legacy.sop
-   :members:
-   :special-members: __call__
-   :undoc-members:
-   :show-inheritance:
-
-
 .. _highdicom-seg-subpackage:
 
 highdicom.seg package
 ---------------------
 
 .. automodule:: highdicom.seg
-   :members:
-   :special-members: __call__
-   :undoc-members:
-   :show-inheritance:
-
-highdicom.seg.content module
-++++++++++++++++++++++++++++
-
-.. automodule:: highdicom.seg.content
-   :members:
-   :special-members: __call__
-   :undoc-members:
-   :show-inheritance:
-
-highdicom.seg.enum module
-+++++++++++++++++++++++++
-
-.. automodule:: highdicom.seg.enum
-   :members:
-   :special-members: __call__
-   :undoc-members:
-   :show-inheritance:
-
-highdicom.seg.sop module
-++++++++++++++++++++++++
-
-.. automodule:: highdicom.seg.sop
    :members:
    :special-members: __call__
    :undoc-members:
@@ -167,42 +112,6 @@ highdicom.sr package
    :undoc-members:
    :show-inheritance:
 
-highdicom.sr.coding module
-++++++++++++++++++++++++++
-
-.. automodule:: highdicom.sr.coding
-   :members:
-   :special-members: __call__
-   :undoc-members:
-   :show-inheritance:
-
-highdicom.sr.content module
-+++++++++++++++++++++++++++
-
-.. automodule:: highdicom.sr.content
-   :members:
-   :special-members: __call__
-   :undoc-members:
-   :show-inheritance:
-
-highdicom.sr.enum module
-++++++++++++++++++++++++
-
-.. automodule:: highdicom.sr.enum
-   :members:
-   :special-members: __call__
-   :undoc-members:
-   :show-inheritance:
-
-highdicom.sr.sop module
-+++++++++++++++++++++++
-
-.. automodule:: highdicom.sr.sop
-   :members:
-   :special-members: __call__
-   :undoc-members:
-   :show-inheritance:
-
 highdicom.sr.utils module
 +++++++++++++++++++++++++
 
@@ -212,49 +121,12 @@ highdicom.sr.utils module
    :undoc-members:
    :show-inheritance:
 
-highdicom.sr.templates module
-+++++++++++++++++++++++++++++
-
-.. automodule:: highdicom.sr.templates
-   :members:
-   :special-members: __call__
-   :undoc-members:
-   :show-inheritance:
-
-highdicom.sr.value\_types module
-++++++++++++++++++++++++++++++++
-
-.. automodule:: highdicom.sr.value_types
-   :members:
-   :special-members: __call__
-   :undoc-members:
-   :show-inheritance:
-
-
 .. _highdicom-sc-subpackage:
 
 highdicom.sc package
 ---------------------
 
 .. automodule:: highdicom.sc
-   :members:
-   :special-members: __call__
-   :undoc-members:
-   :show-inheritance:
-
-highdicom.sc.enum module
-+++++++++++++++++++++++++
-
-.. automodule:: highdicom.sc.enum
-   :members:
-   :special-members: __call__
-   :undoc-members:
-   :show-inheritance:
-
-highdicom.sc.sop module
-++++++++++++++++++++++++
-
-.. automodule:: highdicom.sc.sop
    :members:
    :special-members: __call__
    :undoc-members:

--- a/src/highdicom/base.py
+++ b/src/highdicom/base.py
@@ -93,7 +93,7 @@ class SOPClass(Dataset):
             Name of the referring physician
         content_qualification: Union[str, highdicom.enum.ContentQualificationValues], optional
             Indicator of content qualification
-        coding_schemes: Sequence[highdicom.sr.coding.CodingSchemeIdentificationItem], optional
+        coding_schemes: Sequence[highdicom.sr.CodingSchemeIdentificationItem], optional
             private or public coding schemes that are not part of the
             DICOM standard
         series_description: str, optional

--- a/src/highdicom/content.py
+++ b/src/highdicom/content.py
@@ -41,7 +41,7 @@ class AlgorithmIdentificationSequence(DataElementSequence):
         ----------
         name: str
             Name of the algorithm
-        family: Union[pydicom.sr.coding.Code, highdicom.sr.coding.CodedConcept]
+        family: Union[pydicom.sr.coding.Code, highdicom.sr.CodedConcept]
             Kind of algorithm family
         version: str
             Version of the algorithm
@@ -175,7 +175,7 @@ class PlanePositionSequence(DataElementSequence):
 
         Parameters
         ----------
-        other: highdicom.content.PlanePositionSequence
+        other: highdicom.PlanePositionSequence
             Plane position of other image that should be compared
 
         Returns
@@ -255,7 +255,7 @@ class PlaneOrientationSequence(DataElementSequence):
 
         Parameters
         ----------
-        other: highdicom.content.PlaneOrientationSequence
+        other: highdicom.PlaneOrientationSequence
             Plane position of other image that should be compared
 
         Returns
@@ -338,7 +338,7 @@ class SpecimenCollection(ContentSequence):
         """
         Parameters
         ----------
-        procedure: Union[pydicom.sr.coding.Code, highdicom.sr.coding.CodedConcept]
+        procedure: Union[pydicom.sr.coding.Code, highdicom.sr.CodedConcept]
             Procedure used to collect the examined specimen
 
         """  # noqa
@@ -368,13 +368,13 @@ class SpecimenSampling(ContentSequence):
         """
         Parameters
         ----------
-        method: Union[pydicom.sr.coding.Code, highdicom.sr.coding.CodedConcept]
+        method: Union[pydicom.sr.coding.Code, highdicom.sr.CodedConcept]
             Method used to sample the examined specimen from a parent specimen
         parent_specimen_id: str
             Identifier of the parent specimen
-        parent_specimen_type: Union[pydicom.sr.coding.Code, highdicom.sr.coding.CodedConcept]
+        parent_specimen_type: Union[pydicom.sr.coding.Code, highdicom.sr.CodedConcept]
             Type of the parent specimen
-        issuer_of_parent_specimen_id: highdicom.content.IssuerOfIdentifier, optional
+        issuer_of_parent_specimen_id: highdicom.IssuerOfIdentifier, optional
             Issuer who created the parent specimen
 
         """  # noqa
@@ -423,7 +423,7 @@ class SpecimenStaining(ContentSequence):
         """
         Parameters
         ----------
-        substances: Sequence[Union[pydicom.sr.coding.Code, highdicom.sr.coding.CodedConcept]]
+        substances: Sequence[Union[pydicom.sr.coding.Code, highdicom.sr.CodedConcept]]
             Substances used to stain examined specimen(s)
 
         """  # noqa
@@ -467,18 +467,18 @@ class SpecimenPreparationStep(ContentSequence):
         ----------
         specimen_id: str
             Identifier of the processed specimen
-        processing_type: Union[pydicom.sr.coding.Code, highdicom.sr.coding.CodedConcept]
+        processing_type: Union[pydicom.sr.coding.Code, highdicom.sr.CodedConcept]
             Type of processing
-        processing_procedure: Union[highdicom.content.SpecimenCollection, highdicom.content.SpecimenSampling, highdicom.content.SpecimenStaining]
+        processing_procedure: Union[highdicom.SpecimenCollection, highdicom.SpecimenSampling, highdicom.SpecimenStaining]
             Procedure used during processing
         processing_datetime: datetime.datetime, optional
             Datetime of processing
-        processing_description: Union[str, pydicom.sr.coding.Code, highdicom.sr.coding.CodedConcept], optional
+        processing_description: Union[str, pydicom.sr.coding.Code, highdicom.sr.CodedConcept], optional
             Description of processing
-        issuer_of_specimen_id: highdicom.content.IssuerOfIdentifier, optional
-        fixative: Union[pydicom.sr.coding.Code, highdicom.sr.coding.CodedConcept], optional
+        issuer_of_specimen_id: highdicom.IssuerOfIdentifier, optional
+        fixative: Union[pydicom.sr.coding.Code, highdicom.sr.CodedConcept], optional
             Fixative used during processing
-        embedding_medium: Union[pydicom.sr.coding.Code, highdicom.sr.coding.CodedConcept], optional
+        embedding_medium: Union[pydicom.sr.coding.Code, highdicom.sr.CodedConcept], optional
             Embedding medium used during processing
 
         """  # noqa
@@ -566,10 +566,10 @@ class SpecimenDescription(Dataset):
             provided either in form of text or in form of spatial x, y, z
             coordinates specifying the position (offset) relative to the
             three-dimensional slide coordinate system
-        specimen_preparation_steps: Sequence[highdicom.content.SpecimenPreparationStep], optional
+        specimen_preparation_steps: Sequence[highdicom.SpecimenPreparationStep], optional
             Steps that were applied during the preparation of the examined
             specimen in the laboratory prior to image acquisition
-        issuer_of_specimen_id: highdicom.content.IssuerOfIdentifier, optional
+        issuer_of_specimen_id: highdicom.IssuerOfIdentifier, optional
             Description of the issuer of the specimen identifier
 
         """  # noqa

--- a/src/highdicom/sc/sop.py
+++ b/src/highdicom/sc/sop.py
@@ -158,9 +158,9 @@ class SCImage(SOPClass):
         container_identifier: str, optional
             Identifier of the container holding the specimen (required if
             `coordinate_system` is ``"SLIDE"``)
-        issuer_of_container_identifier: highdicom.content.IssuerOfIdentifier, optional
+        issuer_of_container_identifier: highdicom.IssuerOfIdentifier, optional
             Issuer of `container_identifier`
-        specimen_descriptions: Sequence[highdicom.content.SpecimenDescriptions], optional
+        specimen_descriptions: Sequence[highdicom.SpecimenDescriptions], optional
             Description of each examined specimen (required if
             `coordinate_system` is ``"SLIDE"``)
         transfer_syntax_uid: str, optional

--- a/src/highdicom/seg/__init__.py
+++ b/src/highdicom/seg/__init__.py
@@ -7,6 +7,10 @@ from highdicom.seg.enum import (
     SpatialLocationsPreservedValues,
     SegmentsOverlapValues,
 )
+from highdicom.seg.content import (
+    SegmentDescription,
+    DimensionIndexSequence,
+)
 from highdicom.seg import utils
 
 SOP_CLASS_UIDS = {

--- a/src/highdicom/seg/content.py
+++ b/src/highdicom/seg/content.py
@@ -47,32 +47,32 @@ class SegmentDescription(Dataset):
             Number of the segment.
         segment_label: str
             Label of the segment
-        segmented_property_category: Union[pydicom.sr.coding.Code, highdicom.sr.coding.CodedConcept]
+        segmented_property_category: Union[pydicom.sr.coding.Code, highdicom.sr.CodedConcept]
             Category of the property the segment represents,
             e.g. ``Code("49755003", "SCT", "Morphologically Abnormal Structure")``
             (see `CID 7150 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_7150.html>`_
             "Segmentation Property Categories")
-        segmented_property_type: Union[pydicom.sr.coding.Code, highdicom.sr.coding.CodedConcept]
+        segmented_property_type: Union[pydicom.sr.coding.Code, highdicom.sr.CodedConcept]
             Property the segment represents,
             e.g. ``Code("108369006", "SCT", "Neoplasm")``
             (see `CID 7151 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_7151.html>`_
             "Segmentation Property Types")
-        algorithm_type: Union[str, highdicom.seg.enum.SegmentAlgorithmTypeValues]
+        algorithm_type: Union[str, highdicom.seg.SegmentAlgorithmTypeValues]
             Type of algorithm
-        algorithm_identification: highdicom.content.AlgorithmIdentificationSequence, optional
+        algorithm_identification: highdicom.AlgorithmIdentificationSequence, optional
             Information useful for identification of the algorithm, such
             as its name or version. Required unless the algorithm type is `MANUAL`
         tracking_uid: str, optional
             Unique tracking identifier (universally unique)
         tracking_id: str, optional
             Tracking identifier (unique only with the domain of use)
-        anatomic_regions: Sequence[Union[pydicom.sr.coding.Code, highdicom.sr.coding.CodedConcept]], optional
+        anatomic_regions: Sequence[Union[pydicom.sr.coding.Code, highdicom.sr.CodedConcept]], optional
             Anatomic region(s) into which segment falls,
             e.g. ``Code("41216001", "SCT", "Prostate")``
             (see `CID 4 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_4.html>`_
             "Anatomic Region", `CID 4031 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_4031.html>`_ "Common Anatomic Regions", as
             as well as other CIDs for domain-specific anatomic regions)
-        primary_anatomic_structures: Sequence[Union[highdicom.sr.coding.Code, highdicom.sr.coding.CodedConcept]], optional
+        primary_anatomic_structures: Sequence[Union[highdicom.sr.Code, highdicom.sr.CodedConcept]], optional
             Anatomic structure(s) the segment represents
             (see CIDs for domain-specific primary anatomic structures)
 

--- a/src/highdicom/seg/content.py
+++ b/src/highdicom/seg/content.py
@@ -307,7 +307,7 @@ class DimensionIndexSequence(DataElementSequence):
 
         Returns
         -------
-        List[PlanePositionSequence]
+        List[highdicom.PlanePositionSequence]
             Plane position of each frame in the image
 
         """
@@ -348,7 +348,7 @@ class DimensionIndexSequence(DataElementSequence):
 
         Returns
         -------
-        List[PlanePositionSequence]
+        List[highdicom.PlanePositionSequence]
             Plane position of each frame in the image
 
         """
@@ -376,7 +376,7 @@ class DimensionIndexSequence(DataElementSequence):
 
         Parameters
         ----------
-        plane_positions: Sequence[PlanePositionSequence]
+        plane_positions: Sequence[highdicom.PlanePositionSequence]
             Plane position of frames in a multi-frame image or in a series of
             single-frame images
 

--- a/src/highdicom/seg/sop.py
+++ b/src/highdicom/seg/sop.py
@@ -113,9 +113,9 @@ class Segmentation(SOPClass):
             the column dimension, which are defined in the three-dimensional
             slide coordinate system by the direction cosines encoded by the
             *Image Orientation (Slide)* attribute).
-        segmentation_type: Union[str, highdicom.seg.enum.SegmentationTypeValues]
+        segmentation_type: Union[str, highdicom.seg.SegmentationTypeValues]
             Type of segmentation, either ``"BINARY"`` or ``"FRACTIONAL"``
-        segment_descriptions: Sequence[highdicom.seg.content.SegmentDescription]
+        segment_descriptions: Sequence[highdicom.seg.SegmentDescription]
             Description of each segment encoded in `pixel_array`. In the case of
             pixel arrays with multiple integer values, the segment description
             with the corresponding segment number is used to describe each segment.
@@ -135,7 +135,7 @@ class Segmentation(SOPClass):
             application) that creates the instance
         software_versions: Union[str, Tuple[str]]
             Version(s) of the software that creates the instance
-        fractional_type: Union[str, highdicom.seg.enum.SegmentationFractionalTypeValues], optional
+        fractional_type: Union[str, highdicom.seg.SegmentationFractionalTypeValues], optional
             Type of fractional segmentation that indicates how pixel data
             should be interpreted
         max_fractional_value: int, optional
@@ -156,12 +156,12 @@ class Segmentation(SOPClass):
             Physical spacing of image pixels in `pixel_array`.
             If ``None``, it will be assumed that the segmentation image has the
             same pixel measures as the source image(s).
-        plane_orientation: highdicom.content.PlaneOrientationSequence, optional
+        plane_orientation: highdicom.PlaneOrientationSequence, optional
             Orientation of planes in `pixel_array` relative to axes of
             three-dimensional patient or slide coordinate space.
             If ``None``, it will be assumed that the segmentation image as the
             same plane orientation as the source image(s).
-        plane_positions: Sequence[highdicom.content.PlanePositionSequence], optional
+        plane_positions: Sequence[highdicom.PlanePositionSequence], optional
             Position of each plane in `pixel_array` in the three-dimensional
             patient or slide coordinate space.
             If ``None``, it will be assumed that the segmentation image has the
@@ -467,12 +467,12 @@ class Segmentation(SOPClass):
             the column dimension, which are defined in the three-dimensional
             slide coordinate system by the direction cosines encoded by the
             *Image Orientation (Slide)* attribute).
-        segment_descriptions: Sequence[highdicom.seg.content.SegmentDescription]
+        segment_descriptions: Sequence[highdicom.seg.SegmentDescription]
             Description of each segment encoded in `pixel_array`. In the case of
             pixel arrays with multiple integer values, the segment description
             with the corresponding segment number is used to describe each
             segment.
-        plane_positions: Sequence[highdicom.content.PlanePositionSequence], optional
+        plane_positions: Sequence[highdicom.PlanePositionSequence], optional
             Position of each plane in `pixel_array` relative to the
             three-dimensional patient or slide coordinate system.
 

--- a/src/highdicom/sr/coding.py
+++ b/src/highdicom/sr/coding.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Optional, Sequence
+from typing import Any, Optional
 
 from pydicom.dataset import Dataset
 from pydicom.sr.coding import Code

--- a/src/highdicom/sr/coding.py
+++ b/src/highdicom/sr/coding.py
@@ -52,7 +52,7 @@ class CodedConcept(Dataset):
 
         Parameters
         ----------
-        other: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code]
+        other: Union[highdicom.sr.CodedConcept, pydicom.sr.coding.Code]
             code
 
         Returns

--- a/src/highdicom/sr/content.py
+++ b/src/highdicom/sr/content.py
@@ -110,9 +110,9 @@ class LongitudinalTemporalOffsetFromEvent(NumContentItem):
         ----------
         value: Union[int, float], optional
             offset in time from a particular event of significance
-        unit: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
+        unit: Union[highdicom.sr.CodedConcept, pydicom.sr.coding.Code], optional
             unit of time, e.g., "Days" or "Seconds"
-        event_type: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
+        event_type: Union[highdicom.sr.CodedConcept, pydicom.sr.coding.Code], optional
             type of event to which offset is relative,
             e.g., "Baseline" or "Enrollment"
 
@@ -204,7 +204,7 @@ class SourceImageForMeasurement(ImageContentItem):
 
         Returns
         -------
-        highdicom.sr.content.SourceImageForMeasurement
+        highdicom.sr.SourceImageForMeasurement
             Content item representing a reference to the image dataset
 
         """
@@ -286,7 +286,7 @@ class SourceImageForRegion(ImageContentItem):
 
         Returns
         -------
-        highdicom.sr.content.SourceImageForRegion
+        highdicom.sr.SourceImageForRegion
             Content item representing a reference to the image dataset
 
         """
@@ -368,7 +368,7 @@ class SourceImageForSegmentation(ImageContentItem):
 
         Returns
         -------
-        highdicom.sr.content.SourceImageForSegmentation
+        highdicom.sr.SourceImageForSegmentation
             Content item representing a reference to the image dataset
 
         """
@@ -424,7 +424,7 @@ class SourceSeriesForSegmentation(UIDRefContentItem):
 
         Returns
         -------
-        highdicom.sr.content.SourceSeriesForSegmentation
+        highdicom.sr.SourceSeriesForSegmentation
             Content item representing a reference to the image dataset
 
         """
@@ -452,21 +452,21 @@ class ImageRegion(ScoordContentItem):
         """
         Parameters
         ----------
-        graphic_type: Union[highdicom.sr.enum.GraphicTypeValues, str]
+        graphic_type: Union[highdicom.sr.GraphicTypeValues, str]
             name of the graphic type
         graphic_data: numpy.ndarray
             array of ordered spatial coordinates, where each row of the array
             represents a (column, row) coordinate pair
         source_image: highdicom.sr.template.SourceImageForRegion
             source image to which `graphic_data` relates
-        pixel_origin_interpretation: Union[highdicom.sr.enum.PixelOriginInterpretationValues, str], optional
+        pixel_origin_interpretation: Union[highdicom.sr.PixelOriginInterpretationValues, str], optional
             whether pixel coordinates specified by `graphic_data` are defined
             relative to the total pixel matrix
-            (``highdicom.sr.enum.PixelOriginInterpretationValues.VOLUME``) or
+            (``highdicom.sr.PixelOriginInterpretationValues.VOLUME``) or
             relative to an individual frame
-            (``highdicom.sr.enum.PixelOriginInterpretationValues.FRAME``)
+            (``highdicom.sr.PixelOriginInterpretationValues.FRAME``)
             of the source image
-            (default: ``highdicom.sr.enum.PixelOriginInterpretationValues.VOLUME``)
+            (default: ``highdicom.sr.PixelOriginInterpretationValues.VOLUME``)
 
         """  # noqa
         graphic_type = GraphicTypeValues(graphic_type)
@@ -516,7 +516,7 @@ class ImageRegion3D(Scoord3DContentItem):
         """
         Parameters
         ----------
-        graphic_type: Union[highdicom.sr.enum.GraphicTypeValues3D, str]
+        graphic_type: Union[highdicom.sr.GraphicTypeValues3D, str]
             name of the graphic type
         graphic_data: numpy.ndarray
             array of ordered spatial coordinates, where each row of the array
@@ -566,16 +566,16 @@ class VolumeSurface(Scoord3DContentItem):
         """
         Parameters
         ----------
-        graphic_type: Union[highdicom.sr.enum.GraphicTypeValues3D, str]
+        graphic_type: Union[highdicom.sr.GraphicTypeValues3D, str]
             name of the graphic type
         graphic_data: Sequence[Sequence[int]]
             ordered set of (row, column, frame) coordinate pairs
         frame_of_reference_uid: str
             unique identifier of the frame of reference within which the
             coordinates are defined
-        source_images: Sequence[highdicom.sr.content.SourceImageForSegmentation], optional
+        source_images: Sequence[highdicom.sr.SourceImageForSegmentation], optional
             source images for segmentation
-        source_series: highdicom.sr.content.SourceSeriesForSegmentation, optional
+        source_series: highdicom.sr.SourceSeriesForSegmentation, optional
             source series for segmentation
 
         Note
@@ -660,7 +660,7 @@ class RealWorldValueMap(CompositeContentItem):
 
         Returns
         -------
-        highdicom.sr.content.RealWorldValueMap
+        highdicom.sr.RealWorldValueMap
             Content item representing a reference to the image dataset
 
         """
@@ -686,13 +686,13 @@ class FindingSite(CodeContentItem):
         """
         Parameters
         ----------
-        anatomic_location: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code]
+        anatomic_location: Union[highdicom.sr.CodedConcept, pydicom.sr.coding.Code]
             coded anatomic location (region or structure)
-        laterality: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
+        laterality: Union[highdicom.sr.CodedConcept, pydicom.sr.coding.Code], optional
             coded laterality
             (see `CID 244 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_244.html>`_
             "Laterality" for options)
-        topographical_modifier: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
+        topographical_modifier: Union[highdicom.sr.CodedConcept, pydicom.sr.coding.Code], optional
             coded modifier of anatomic location
 
         """  # noqa
@@ -757,7 +757,7 @@ class ReferencedSegmentationFrame(ContentSequence):
             number of the segment to which the refernce applies
         frame_number: int
             number of the frame to which the reference applies
-        source_image: highdicom.sr.content.SourceImageForSegmentation
+        source_image: highdicom.sr.SourceImageForSegmentation
             source image for segmentation
 
         """
@@ -801,7 +801,7 @@ class ReferencedSegmentationFrame(ContentSequence):
 
         Returns
         -------
-        highdicom.sr.content.ReferencedSegment
+        highdicom.sr.ReferencedSegment
             Content item representing a reference to the segment
 
         Notes
@@ -940,9 +940,9 @@ class ReferencedSegment(ContentSequence):
         frame_numbers: Sequence[int], optional
             numbers of the frames to which the reference applies
             (in case a segmentation instance is referenced)
-        source_images: Sequence[highdicom.sr.content.SourceImageForSegmentation], optional
+        source_images: Sequence[highdicom.sr.SourceImageForSegmentation], optional
             source images for segmentation
-        source_series: highdicom.sr.content.SourceSeriesForSegmentation, optional
+        source_series: highdicom.sr.SourceSeriesForSegmentation, optional
             source series for segmentation
 
         Note
@@ -1010,7 +1010,7 @@ class ReferencedSegment(ContentSequence):
 
         Returns
         -------
-        highdicom.sr.content.ReferencedSegment
+        highdicom.sr.ReferencedSegment
             Content item representing a reference to the segment
 
         Notes

--- a/src/highdicom/sr/sop.py
+++ b/src/highdicom/sr/sop.py
@@ -96,7 +96,7 @@ class _SR(SOPClass):
         verifying_organization: str, optional
             Name of the organization that verfied the SR document
             (required if `is_verified`)
-        performed_procedure_codes: List[highdicom.sr.coding.CodedConcept], optional
+        performed_procedure_codes: List[highdicom.sr.CodedConcept], optional
             Codes of the performed procedures that resulted in the SR document
         requested_procedures: List[pydicom.dataset.Dataset], optional
             Requested procedures that are being fullfilled by creation of the
@@ -423,7 +423,7 @@ class EnhancedSR(_SR):
         verifying_organization: str, optional
             Name of the organization that verfied the SR document
             (required if `is_verified`)
-        performed_procedure_codes: List[highdicom.sr.coding.CodedConcept], optional
+        performed_procedure_codes: List[highdicom.sr.CodedConcept], optional
             Codes of the performed procedures that resulted in the SR document
         requested_procedures: List[pydicom.dataset.Dataset], optional
             Requested procedures that are being fullfilled by creation of the
@@ -551,7 +551,7 @@ class ComprehensiveSR(_SR):
         verifying_organization: str, optional
             Name of the organization that verfied the SR document
             (required if `is_verified`)
-        performed_procedure_codes: List[highdicom.sr.coding.CodedConcept], optional
+        performed_procedure_codes: List[highdicom.sr.CodedConcept], optional
             Codes of the performed procedures that resulted in the SR document
         requested_procedures: List[pydicom.dataset.Dataset]
             Requested procedures that are being fullfilled by creation of the
@@ -679,7 +679,7 @@ class Comprehensive3DSR(_SR):
         verifying_organization: str, optional
             Name of the organization that verfied the SR document
             (required if `is_verified`)
-        performed_procedure_codes: List[highdicom.sr.coding.CodedConcept], optional
+        performed_procedure_codes: List[highdicom.sr.CodedConcept], optional
             Codes of the performed procedures that resulted in the SR document
         requested_procedures: List[pydicom.dataset.Dataset]
             Requested procedures that are being fullfilled by creation of the

--- a/src/highdicom/sr/templates.py
+++ b/src/highdicom/sr/templates.py
@@ -178,7 +178,7 @@ class TimePointContext(Template):
         ----------
         time_point: str
             actual value representation of the time point
-        time_point_type: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
+        time_point_type: Union[highdicom.sr.CodedConcept, pydicom.sr.coding.Code], optional
             coded type of time point, e.g., "Baseline" or "Posttreatment" (see
             `CID 6146 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_6146.html>`_
             "Time Point Types" for options)
@@ -193,7 +193,7 @@ class TimePointContext(Template):
            identifier of a specific time point in a time series, which is
            unique within an appropriate local context and specific to a
            particular protocol using the same value for different subjects
-        temporal_offset_from_event: highdicom.sr.content.LongitudinalTemporalOffsetFromEvent, optional
+        temporal_offset_from_event: highdicom.sr.LongitudinalTemporalOffsetFromEvent, optional
             offset in time from a particular event of significance, e.g., the
             baseline of an imaging study or enrollment into a clinical trial
 
@@ -279,7 +279,7 @@ class MeasurementStatisticalProperties(Template):
 
         Parameters
         ----------
-        values: Sequence[highdicom.sr.value_types.NumContentItem]
+        values: Sequence[highdicom.sr.NumContentItem]
             reference values of the population of measurements, e.g., its
             mean or standard deviation (see
             `CID 226 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_226.html>`_
@@ -342,7 +342,7 @@ class NormalRangeProperties(Template):
 
         Parameters
         ----------
-        values: Sequence[highdicom.sr.value_types.NumContentItem]
+        values: Sequence[highdicom.sr.NumContentItem]
             reference values of the normal range, e.g., its upper and lower
             bound (see
             `CID 223 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_223.html>`_
@@ -400,23 +400,23 @@ class MeasurementProperties(Template):
 
         Parameters
         ----------
-        normality: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
+        normality: Union[highdicom.sr.CodedConcept, pydicom.sr.coding.Code], optional
             the extend to which the measurement is considered normal or abnormal
             (see `CID 222 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_222.html>`_
             "Normality Codes" for options)
-        level_of_significance: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
+        level_of_significance: Union[highdicom.sr.CodedConcept, pydicom.sr.coding.Code], optional
             the extend to which the measurement is considered normal or abnormal
             (see `CID 220 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_220.html>`_
             "Level of Significance" for options)
-        selection_status: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
+        selection_status: Union[highdicom.sr.CodedConcept, pydicom.sr.coding.Code], optional
             how the measurement value was selected or computed from a set of
             available values (see
             `CID 224 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_224.html>`_
             "Selection Method" for options)
-        measurement_statistical_properties: highdicom.sr.templates.MeasurementStatisticalProperties, optional
+        measurement_statistical_properties: highdicom.sr.MeasurementStatisticalProperties, optional
             statistical properties of a reference population for a measurement
             and/or the position of a measurement in such a reference population
-        normal_range_properties: highdicom.sr.templates.NormalRangeProperties, optional
+        normal_range_properties: highdicom.sr.NormalRangeProperties, optional
             statistical properties of a reference population for a measurement
             and/or the position of a measurement in such a reference population
         upper_measurement_uncertainty: Union[int, float], optional
@@ -522,9 +522,9 @@ class PersonObserverIdentifyingAttributes(Template):
             login name of the person
         organization_name: str, optional
             name of the person's organization
-        role_in_organization: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
+        role_in_organization: Union[highdicom.sr.CodedConcept, pydicom.sr.coding.Code], optional
             role of the person within the organization
-        role_in_procedure: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
+        role_in_procedure: Union[highdicom.sr.CodedConcept, pydicom.sr.coding.Code], optional
             role of the person in the reported procedure
 
         """  # noqa
@@ -697,11 +697,11 @@ class ObserverContext(Template):
 
         Parameters
         ----------
-        observer_type: highdicom.sr.coding.CodedConcept
+        observer_type: highdicom.sr.CodedConcept
             type of observer (see
             `CID 270 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_270.html>`_
             "Observer Type" for options)
-        observer_identifying_attributes: Union[highdicom.sr.templates.PersonObserverIdentifyingAttributes, highdicom.sr.templates.DeviceObserverIdentifyingAttributes]
+        observer_identifying_attributes: Union[highdicom.sr.PersonObserverIdentifyingAttributes, highdicom.sr.DeviceObserverIdentifyingAttributes]
             observer identifying attributes
 
         """  # noqa
@@ -794,7 +794,7 @@ class SubjectContextSpecimen(Template):
         container_identifier: str, optional
             identifier of the container holding the speciment (e.g., a glass
             slide)
-        specimen_type: highdicom.sr.coding.CodedConcept, optional
+        specimen_type: highdicom.sr.CodedConcept, optional
             type of the specimen (see
             `CID 8103 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_8103.html>`_
             "Anatomic Pathology Specimen Types" for options)
@@ -954,11 +954,11 @@ class SubjectContext(Template):
 
         Parameters
         ----------
-        subject_class: highdicom.sr.coding.CodedConcept
+        subject_class: highdicom.sr.CodedConcept
             type of subject if the subject of the report is not the patient
             (see `CID 271 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_271.html>`_
             "Observation Subject Class" for options)
-        subject_class_specific_context: Union[highdicom.sr.templates.SubjectContextFetus, highdicom.sr.templates.SubjectContextSpecimen, highdicom.sr.templates.SubjectContextDevice], optional
+        subject_class_specific_context: Union[highdicom.sr.SubjectContextFetus, highdicom.sr.SubjectContextSpecimen, highdicom.sr.SubjectContextDevice], optional
             additional context information specific to `subject_class`
 
         """  # noqa
@@ -992,12 +992,12 @@ class ObservationContext(Template):
 
         Parameters
         ----------
-        observer_person_context: [highdicom.sr.templates.ObserverContext, None], optional
+        observer_person_context: [highdicom.sr.ObserverContext, None], optional
             description of the person that reported the observation
-        observer_device_context: highdicom.sr.templates.ObserverContext, optional
+        observer_device_context: highdicom.sr.ObserverContext, optional
             description of the device that was involved in reporting the
             observation
-        subject_context: highdicom.sr.templates.SubjectContext, optional
+        subject_context: highdicom.sr.SubjectContext, optional
             description of the imaging subject in case it is not the patient
             for which the report is generated (e.g., a pathology specimen in
             a whole-slide microscopy image, a fetus in an ultrasound image, or
@@ -1043,7 +1043,7 @@ class LanguageOfContentItemAndDescendants(Template):
 
         Parameters
         ----------
-        language: highdicom.sr.coding.CodedConcept
+        language: highdicom.sr.CodedConcept
             language used for content items included in report
 
         """
@@ -1084,45 +1084,45 @@ class Measurement(Template):
 
         Parameters
         ----------
-        name: highdicom.sr.coding.CodedConcept
+        name: highdicom.sr.CodedConcept
             Name of the measurement (see
             `CID 7469 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_7469.html>`_
             "Generic Intensity and Size Measurements" and
             `CID 7468 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_7468.html>`_
             "Texture Measurements" for options)
-        tracking_identifier: highdicom.sr.templates.TrackingIdentifier, optional
+        tracking_identifier: highdicom.sr.TrackingIdentifier, optional
             Identifier for tracking measurements
         value: Union[int, float], optional
             Numeric measurement value
-        unit: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
+        unit: Union[highdicom.sr.CodedConcept, pydicom.sr.coding.Code], optional
             Unit of the numeric measurement value (see
             `CID 7181 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_7181.html>`_
             "Abstract Multi-dimensional Image Model Component
             Units" for options)
-        qualifier: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
+        qualifier: Union[highdicom.sr.CodedConcept, pydicom.sr.coding.Code], optional
             Qualification of numeric measurement value or as an alternative
             qualitative description
-        algorithm_id: highdicom.sr.templates.AlgorithmIdentification, optional
+        algorithm_id: highdicom.sr.AlgorithmIdentification, optional
             Identification of algorithm used for making measurements
-        derivation: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
+        derivation: Union[highdicom.sr.CodedConcept, pydicom.sr.coding.Code], optional
             How the value was computed (see
             `CID 7464 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_7464.html>`_
             "General Region of Interest Measurement Modifiers"
             for options)
-        finding_sites: Sequence[highdicom.sr.content.FindingSite], optional
+        finding_sites: Sequence[highdicom.sr.FindingSite], optional
             Coded description of one or more anatomic locations corresonding
             to the image region from which measurement was taken
-        method: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
+        method: Union[highdicom.sr.CodedConcept, pydicom.sr.coding.Code], optional
             Measurement method (see
             `CID 6147 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_6147.html>`_
             "Response Criteria" for options)
-        properties: highdicom.sr.templates.MeasurementProperties, optional
+        properties: highdicom.sr.MeasurementProperties, optional
             Measurement properties, including evaluations of its normality
             and/or significance, its relationship to a reference population,
             and an indication of its selection from a set of measurements
-        referenced_images: Sequence[highdicom.sr.content.SourceImageForMeasurement], optional
+        referenced_images: Sequence[highdicom.sr.SourceImageForMeasurement], optional
             Referenced images which were used as sources for the measurement
-        referenced_real_world_value_map: highdicom.sr.content.RealWorldValueMap, optional
+        referenced_real_world_value_map: highdicom.sr.RealWorldValueMap, optional
             Referenced real world value map for referenced source images
 
         """  # noqa
@@ -1232,28 +1232,28 @@ class MeasurementsAndQualitativeEvaluations(Template):
 
         Parameters
         ----------
-        tracking_identifier: highdicom.sr.templates.TrackingIdentifier
+        tracking_identifier: highdicom.sr.TrackingIdentifier
             Identifier for tracking measurements
-        referenced_real_world_value_map: highdicom.sr.content.RealWorldValueMap, optional
+        referenced_real_world_value_map: highdicom.sr.RealWorldValueMap, optional
             Referenced real world value map for region of interest
-        time_point_context: highdicom.sr.templates.TimePointContext, optional
+        time_point_context: highdicom.sr.TimePointContext, optional
             Description of the time point context
-        finding_type: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
+        finding_type: Union[highdicom.sr.CodedConcept, pydicom.sr.coding.Code], optional
             Type of object that was measured, e.g., organ or tumor
-        method: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
+        method: Union[highdicom.sr.CodedConcept, pydicom.sr.coding.Code], optional
             coded measurement method (see
             `CID 6147 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_6147.html>`_
             "Response Criteria" for options)
-        algorithm_id: highdicom.sr.templates.AlgorithmIdentification, optional
+        algorithm_id: highdicom.sr.AlgorithmIdentification, optional
             identification of algorithm used for making measurements
-        finding_sites: Sequence[highdicom.sr.content.FindingSite], optional
+        finding_sites: Sequence[highdicom.sr.FindingSite], optional
             Coded description of one or more anatomic locations corresonding
             to the image region from which measurement was taken
         session: str, optional
             Description of the session
-        measurements: Sequence[highdicom.sr.templates.Measurement], optional
+        measurements: Sequence[highdicom.sr.Measurement], optional
             Numeric measurements
-        qualitative_evaluations: Sequence[highdicom.sr.value_types.CodeContentItem], optional
+        qualitative_evaluations: Sequence[highdicom.sr.CodeContentItem], optional
             Coded name-value pairs that describe measurements in qualitative
             terms
 
@@ -1398,37 +1398,37 @@ class _ROIMeasurementsAndQualitativeEvaluations(
 
         Parameters
         ----------
-        tracking_identifier: highdicom.sr.templates.TrackingIdentifier
+        tracking_identifier: highdicom.sr.TrackingIdentifier
             identifier for tracking measurements
-        referenced_regions: Union[Sequence[highdicom.sr.content.ImageRegion], Sequence[highdicom.sr.content.ImageRegion3D]], optional
+        referenced_regions: Union[Sequence[highdicom.sr.ImageRegion], Sequence[highdicom.sr.ImageRegion3D]], optional
             regions of interest in source image(s)
-        referenced_segment: Union[highdicom.sr.content.ReferencedSegment, highdicom.sr.content.ReferencedSegmentationFrame], optional
+        referenced_segment: Union[highdicom.sr.ReferencedSegment, highdicom.sr.ReferencedSegmentationFrame], optional
             segmentation for region of interest in source image
         referenced_volume_surface: hidicom.sr.content.VolumeSurface, optional
             surface segmentation for region of interest in source image
-        referenced_real_world_value_map: highdicom.sr.content.RealWorldValueMap, optional
+        referenced_real_world_value_map: highdicom.sr.RealWorldValueMap, optional
             referenced real world value map for region of interest
-        time_point_context: highdicom.sr.templates.TimePointContext, optional
+        time_point_context: highdicom.sr.TimePointContext, optional
             description of the time point context
-        finding_type: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
+        finding_type: Union[highdicom.sr.CodedConcept, pydicom.sr.coding.Code], optional
             type of object that was measured, e.g., organ or tumor
-        method: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
+        method: Union[highdicom.sr.CodedConcept, pydicom.sr.coding.Code], optional
             coded measurement method (see
             `CID 6147 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_6147.html>`_
             "Response Criteria" for options)
-        algorithm_id: highdicom.sr.templates.AlgorithmIdentification, optional
+        algorithm_id: highdicom.sr.AlgorithmIdentification, optional
             identification of algorithm used for making measurements
-        finding_sites: Sequence[highdicom.sr.content.FindingSite], optional
+        finding_sites: Sequence[highdicom.sr.FindingSite], optional
             Coded description of one or more anatomic locations corresonding
             to the image region from which measurement was taken
         session: str, optional
             description of the session
-        measurements: Sequence[highdicom.sr.templates.Measurement], optional
+        measurements: Sequence[highdicom.sr.Measurement], optional
             numeric measurements
-        qualitative_evaluations: Sequence[highdicom.sr.value_types.CodeContentItem], optional
+        qualitative_evaluations: Sequence[highdicom.sr.CodeContentItem], optional
             coded name-value (question-answer) pairs that describe the
             measurements in qualitative terms
-        geometric_purpose: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
+        geometric_purpose: Union[highdicom.sr.CodedConcept, pydicom.sr.coding.Code], optional
             geometric interpretation of region of interest (see
             `CID 219 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_219.html>`_
             "Geometry Graphical Representation" for options)
@@ -1544,35 +1544,35 @@ class PlanarROIMeasurementsAndQualitativeEvaluations(
 
         Parameters
         ----------
-        tracking_identifier: highdicom.sr.templates.TrackingIdentifier
+        tracking_identifier: highdicom.sr.TrackingIdentifier
             identifier for tracking measurements
-        referenced_region: Union[highdicom.sr.content.ImageRegion, highdicom.sr.content.ImageRegion3D], optional
+        referenced_region: Union[highdicom.sr.ImageRegion, highdicom.sr.ImageRegion3D], optional
             region of interest in source image
-        referenced_segment: highdicom.sr.content.ReferencedSegmentationFrame, optional
+        referenced_segment: highdicom.sr.ReferencedSegmentationFrame, optional
             segmentation for region of interest in source image
-        referenced_real_world_value_map: highdicom.sr.content.RealWorldValueMap, optional
+        referenced_real_world_value_map: highdicom.sr.RealWorldValueMap, optional
             referenced real world value map for region of interest
-        time_point_context: highdicom.sr.templates.TimePointContext, optional
+        time_point_context: highdicom.sr.TimePointContext, optional
             description of the time point context
-        finding_type: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
+        finding_type: Union[highdicom.sr.CodedConcept, pydicom.sr.coding.Code], optional
             type of object that was measured, e.g., organ or tumor
-        method: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
+        method: Union[highdicom.sr.CodedConcept, pydicom.sr.coding.Code], optional
             coded measurement method (see
             `CID 6147 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_6147.html>`_
             "Response Criteria" for options)
-        algorithm_id: highdicom.sr.templates.AlgorithmIdentification, optional
+        algorithm_id: highdicom.sr.AlgorithmIdentification, optional
             identification of algorithm used for making measurements
-        finding_sites: Sequence[highdicom.sr.content.FindingSite], optional
+        finding_sites: Sequence[highdicom.sr.FindingSite], optional
             Coded description of one or more anatomic locations corresonding
             to the image region from which measurement was taken
         session: str, optional
             description of the session
-        measurements: Sequence[highdicom.sr.templates.Measurement], optional
+        measurements: Sequence[highdicom.sr.Measurement], optional
             measurements for a region of interest
-        qualitative_evaluations: Sequence[highdicom.sr.value_types.CodeContentItem], optional
+        qualitative_evaluations: Sequence[highdicom.sr.CodeContentItem], optional
             coded name-value (question-answer) pairs that describe the
             measurements in qualitative terms for a region of interest
-        geometric_purpose: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
+        geometric_purpose: Union[highdicom.sr.CodedConcept, pydicom.sr.coding.Code], optional
             geometric interpretation of region of interest (see
             `CID 219 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_219.html>`_
             "Geometry Graphical Representation" for options)
@@ -1649,37 +1649,37 @@ class VolumetricROIMeasurementsAndQualitativeEvaluations(
 
         Parameters
         ----------
-        tracking_identifier: highdicom.sr.templates.TrackingIdentifier
+        tracking_identifier: highdicom.sr.TrackingIdentifier
             identifier for tracking measurements
-        referenced_regions: Union[Sequence[highdicom.sr.content.ImageRegion], Sequence[highdicom.sr.content.ImageRegion3D]], optional
+        referenced_regions: Union[Sequence[highdicom.sr.ImageRegion], Sequence[highdicom.sr.ImageRegion3D]], optional
             regions of interest in source image(s)
-        referenced_volume_surface: highdicom.sr.content.VolumeSurface, optional
+        referenced_volume_surface: highdicom.sr.VolumeSurface, optional
             volume of interest in source image(s)
-        referenced_segment: highdicom.sr.content.ReferencedSegment, optional
+        referenced_segment: highdicom.sr.ReferencedSegment, optional
             segmentation for region of interest in source image
-        referenced_real_world_value_map: highdicom.sr.content.RealWorldValueMap, optional
+        referenced_real_world_value_map: highdicom.sr.RealWorldValueMap, optional
             referenced real world value map for region of interest
-        time_point_context: highdicom.sr.templates.TimePointContext, optional
+        time_point_context: highdicom.sr.TimePointContext, optional
             description of the time point context
-        finding_type: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
+        finding_type: Union[highdicom.sr.CodedConcept, pydicom.sr.coding.Code], optional
             type of object that was measured, e.g., organ or tumor
-        method: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
+        method: Union[highdicom.sr.CodedConcept, pydicom.sr.coding.Code], optional
             coded measurement method (see
             `CID 6147 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_6147.html>`_
             "Response Criteria" for options)
-        algorithm_id: highdicom.sr.templates.AlgorithmIdentification, optional
+        algorithm_id: highdicom.sr.AlgorithmIdentification, optional
             identification of algorithm used for making measurements
-        finding_sites: Sequence[highdicom.sr.content.FindingSite], optional
+        finding_sites: Sequence[highdicom.sr.FindingSite], optional
             Coded description of one or more anatomic locations corresonding
             to the image region from which measurement was taken
         session: str, optional
             description of the session
-        measurements: Sequence[highdicom.sr.templates.Measurement], optional
+        measurements: Sequence[highdicom.sr.Measurement], optional
             measurements for a volume of interest
-        qualitative_evaluations: Sequence[highdicom.sr.value_types.CodeContentItem], optional
+        qualitative_evaluations: Sequence[highdicom.sr.CodeContentItem], optional
             coded name-value (question-answer) pairs that describe the
             measurements in qualitative terms for a volume of interest
-        geometric_purpose: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
+        geometric_purpose: Union[highdicom.sr.CodedConcept, pydicom.sr.coding.Code], optional
             geometric interpretation of region of interest (see
             `CID 219 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_219.html>`_
             "Geometry Graphical Representation" for options)
@@ -1726,16 +1726,16 @@ class MeasurementsDerivedFromMultipleROIMeasurements(Template):
 
         Parameters
         ----------
-        derivation: Sequence[highdicom.sr.coding.CodedConcept]
+        derivation: Sequence[highdicom.sr.CodedConcept]
             methods for derivation of measurements from multiple ROIs
             measurements (see
             `CID 7465 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_7465.html>`_
             "Measurements Derived From Multiple ROI Measurements"
             for options)
-        measurement_groups: Union[Sequence[highdicom.sr.templates.PlanarROIMeasurementsAndQualitativeEvaluations], Sequence[highdicom.sr.templates.VolumetricROIMeasurementsAndQualitativeEvaluations]]
+        measurement_groups: Union[Sequence[highdicom.sr.PlanarROIMeasurementsAndQualitativeEvaluations], Sequence[highdicom.sr.VolumetricROIMeasurementsAndQualitativeEvaluations]]
             one or more groups of either planar or volumetric ROI measurements
             and qualitative evaluations
-        measurement_properties: highdicom.sr.templates.MeasurementProperties, optional
+        measurement_properties: highdicom.sr.MeasurementProperties, optional
             measurement properties, including evaluations of its normality
             and/or significance, its relationship to a reference population,
             and an indication of its selection from a set of measurements
@@ -1800,24 +1800,24 @@ class MeasurementReport(Template):
 
         Parameters
         ----------
-        observation_context: highdicom.sr.templates.ObservationContext
+        observation_context: highdicom.sr.ObservationContext
             description of the observation context
-        procedure_reported: Union[Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], Sequence[Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code]]]
+        procedure_reported: Union[Union[highdicom.sr.CodedConcept, pydicom.sr.coding.Code], Sequence[Union[highdicom.sr.CodedConcept, pydicom.sr.coding.Code]]]
             one or more coded description(s) of the procedure (see
             `CID 100 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_100.html>`_
             "Quantitative Diagnostic Imaging Procedures" for options)
-        imaging_measurements: Sequence[Union[highdicom.sr.templates.PlanarROIMeasurementsAndQualitativeEvaluations, highdicom.sr.templates.VolumetricROIMeasurementsAndQualitativeEvaluations, highdicom.sr.templates.MeasurementsAndQualitativeEvaluations]], optional
+        imaging_measurements: Sequence[Union[highdicom.sr.PlanarROIMeasurementsAndQualitativeEvaluations, highdicom.sr.VolumetricROIMeasurementsAndQualitativeEvaluations, highdicom.sr.MeasurementsAndQualitativeEvaluations]], optional
             measurements and qualitative evaluations of images or regions
             within images
-        derived_imaging_measurements: Sequence[highdicom.sr.templates.MeasurementsDerivedFromMultipleROIMeasurements], optional
+        derived_imaging_measurements: Sequence[highdicom.sr.MeasurementsDerivedFromMultipleROIMeasurements], optional
             measurements derived from other measurements of images or regions
             within images
             qualitative evaluations of images
-        title: highdicom.sr.coding.CodedConcept, optional
+        title: highdicom.sr.CodedConcept, optional
             title of the report (see 
             `CID 7021 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_7021.html>`_
             "Measurement Report Document Titles" for options)
-        language_of_content_item_and_descendants: highdicom.sr.templates.LanguageOfContentItemAndDescendants, optional
+        language_of_content_item_and_descendants: highdicom.sr.LanguageOfContentItemAndDescendants, optional
             specification of the language of report content items
             (defaults to English)
 

--- a/src/highdicom/sr/utils.py
+++ b/src/highdicom/sr/utils.py
@@ -23,14 +23,14 @@ def find_content_items(
     ----------
     dataset: pydicom.dataset.Dataset
         SR document instance
-    name: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
+    name: Union[highdicom.sr.CodedConcept, pydicom.sr.coding.Code], optional
         Coded name that items should have
-    value_type: Union[highdicom.sr.enum.ValueTypeValues, str], optional
+    value_type: Union[highdicom.sr.ValueTypeValues, str], optional
         Type of value that items should have
-        (e.g. ``highdicom.sr.enum.ValueTypeValues.CONTAINER``)
-    relationship_type: Union[highdicom.sr.enum.RelationshipTypeValues, str], optional
+        (e.g. ``highdicom.sr.ValueTypeValues.CONTAINER``)
+    relationship_type: Union[highdicom.sr.RelationshipTypeValues, str], optional
         Type of relationship that items should have with its parent
-        (e.g. ``highdicom.sr.enum.RelationshipTypeValues.CONTAINS``)
+        (e.g. ``highdicom.sr.RelationshipTypeValues.CONTAINS``)
     recursive: bool, optional
         Whether search should be performed recursively, i.e. whether contained
         child content items should also be queried
@@ -128,7 +128,7 @@ def get_coded_name(item: Dataset) -> CodedConcept:
 
     Returns
     -------
-    highdicom.sr.coding.CodedConcept
+    highdicom.sr.CodedConcept
         Concept name
 
     """
@@ -157,7 +157,7 @@ def get_coded_value(item: Dataset) -> CodedConcept:
 
     Returns
     -------
-    highdicom.sr.coding.CodedConcept
+    highdicom.sr.CodedConcept
         Value
 
     """

--- a/src/highdicom/sr/utils.py
+++ b/src/highdicom/sr/utils.py
@@ -121,8 +121,8 @@ def find_content_items(
 def get_coded_name(item: Dataset) -> CodedConcept:
     """Gets the concept name of a SR Content Item.
 
-    Parameter
-    ---------
+    Parameters
+    ----------
     item: pydicom.dataset.Dataset
         Content Item
 
@@ -150,8 +150,8 @@ def get_coded_name(item: Dataset) -> CodedConcept:
 def get_coded_value(item: Dataset) -> CodedConcept:
     """Gets the value of a SR Content Item with Value Type CODE.
 
-    Parameter
-    ---------
+    Parameters
+    ----------
     item: pydicom.dataset.Dataset
         Content Item
 

--- a/src/highdicom/sr/value_types.py
+++ b/src/highdicom/sr/value_types.py
@@ -36,11 +36,11 @@ class ContentItem(Dataset):
         """
         Parameters
         ----------
-        value_type: Union[str, highdicom.sr.enum.ValueTypeValues]
+        value_type: Union[str, highdicom.sr.ValueTypeValues]
             type of value encoded in a content item
-        name: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code]
+        name: Union[highdicom.sr.CodedConcept, pydicom.sr.coding.Code]
             coded name or an enumerated item representing a coded name
-        relationship_type: Union[str, highdicom.sr.enum.RelationshipTypeValues], optional
+        relationship_type: Union[str, highdicom.sr.RelationshipTypeValues], optional
             type of relationship with parent content item
 
         """  # noqa
@@ -72,7 +72,7 @@ class ContentItem(Dataset):
     @property
     def value_type(self) -> str:
         """str: type of the content item
-        (see `highdicom.sr.value_types.ValueTypeValues`)
+        (see `highdicom.sr.ValueTypeValues`)
 
         """
         return self.ValueType
@@ -80,7 +80,7 @@ class ContentItem(Dataset):
     @property
     def relationship_type(self) -> str:
         """str: type of relationship the content item has with its parent
-        (see `highdicom.sr.enum.RelationshipTypeValues`)
+        (see `highdicom.sr.RelationshipTypeValues`)
 
         """
         return getattr(self, 'RelationshipType', None)
@@ -112,7 +112,7 @@ class ContentSequence(DataElementSequence):
 
         Returns
         -------
-        highdicom.sr.value_types.ContentSequence[highdicom.sr.value_types.ContentItem]
+        highdicom.sr.ContentSequence[highdicom.sr.ContentItem]
             matched content items
 
         """
@@ -126,7 +126,7 @@ class ContentSequence(DataElementSequence):
 
         Parameters
         ----------
-        item: highdicom.sr.value_types.ContentItem
+        item: highdicom.sr.ContentItem
             content item
 
         """
@@ -143,7 +143,7 @@ class ContentSequence(DataElementSequence):
 
         Parameters
         ----------
-        items: Sequence[highdicom.sr.value_types.ContentItem]
+        items: Sequence[highdicom.sr.ContentItem]
             content items
 
         """
@@ -157,7 +157,7 @@ class ContentSequence(DataElementSequence):
         ----------
         position: int
             index position
-        item: highdicom.sr.value_types.ContentItem
+        item: highdicom.sr.ContentItem
             content item
 
         """
@@ -185,11 +185,11 @@ class CodeContentItem(ContentItem):
         """
         Parameters
         ----------
-        name: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code]
+        name: Union[highdicom.sr.CodedConcept, pydicom.sr.coding.Code]
             concept name
-        value: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code]
+        value: Union[highdicom.sr.CodedConcept, pydicom.sr.coding.Code]
             coded value or an enumerated item representing a coded value
-        relationship_type: Union[highdicom.sr.enum.RelationshipTypeValues, str], optional
+        relationship_type: Union[highdicom.sr.RelationshipTypeValues, str], optional
             type of relationship with parent content item
 
         """  # noqa
@@ -220,11 +220,11 @@ class PnameContentItem(ContentItem):
         """
         Parameters
         ----------
-        name: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code]
+        name: Union[highdicom.sr.CodedConcept, pydicom.sr.coding.Code]
             concept name
         value: Union[str, pydicom.valuerep.PersonName]
             name of the person
-        relationship_type: Union[highdicom.sr.enum.RelationshipTypeValues, str], optional
+        relationship_type: Union[highdicom.sr.RelationshipTypeValues, str], optional
             type of relationship with parent content item
 
         """  # noqa
@@ -249,11 +249,11 @@ class TextContentItem(ContentItem):
         """
         Parameters
         ----------
-        name: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code]
+        name: Union[highdicom.sr.CodedConcept, pydicom.sr.coding.Code]
             concept name
         value: str
             description of the concept in free text
-        relationship_type: Union[highdicom.sr.enum.RelationshipTypeValues, str], optional
+        relationship_type: Union[highdicom.sr.RelationshipTypeValues, str], optional
             type of relationship with parent content item
 
         """ # noqa
@@ -278,11 +278,11 @@ class TimeContentItem(ContentItem):
         """
         Parameters
         ----------
-        name: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code]
+        name: Union[highdicom.sr.CodedConcept, pydicom.sr.coding.Code]
             concept name
         value: Union[str, datetime.time, pydicom.valuerep.TM]
             time
-        relationship_type: Union[highdicom.sr.enum.RelationshipTypeValues, str], optional
+        relationship_type: Union[highdicom.sr.RelationshipTypeValues, str], optional
             type of relationship with parent content item
 
         """  # noqa
@@ -307,11 +307,11 @@ class DateContentItem(ContentItem):
         """
         Parameters
         ----------
-        name: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code]
+        name: Union[highdicom.sr.CodedConcept, pydicom.sr.coding.Code]
             concept name
         value: Union[str, datetime.date, pydicom.valuerep.DA]
             date
-        relationship_type: Union[highdicom.sr.enum.RelationshipTypeValues, str], optional
+        relationship_type: Union[highdicom.sr.RelationshipTypeValues, str], optional
             type of relationship with parent content item
 
         """  # noqa
@@ -336,11 +336,11 @@ class DateTimeContentItem(ContentItem):
         """
         Parameters
         ----------
-        name: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code]
+        name: Union[highdicom.sr.CodedConcept, pydicom.sr.coding.Code]
             concept name
         value: Union[str, datetime.datetime, pydicom.valuerep.DT]
             datetime
-        relationship_type: Union[highdicom.sr.enum.RelationshipTypeValues, str], optional
+        relationship_type: Union[highdicom.sr.RelationshipTypeValues, str], optional
             type of relationship with parent content item
 
         """  # noqa
@@ -365,11 +365,11 @@ class UIDRefContentItem(ContentItem):
         """
         Parameters
         ----------
-        name: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code]
+        name: Union[highdicom.sr.CodedConcept, pydicom.sr.coding.Code]
             concept name
         value: Union[pydicom.uid.UID, str]
             unique identifier
-        relationship_type: Union[highdicom.sr.enum.RelationshipTypeValues, str], optional
+        relationship_type: Union[highdicom.sr.RelationshipTypeValues, str], optional
             type of relationship with parent content item
 
         """  # noqa
@@ -396,19 +396,19 @@ class NumContentItem(ContentItem):
         """
         Parameters
         ----------
-        name: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code]
+        name: Union[highdicom.sr.CodedConcept, pydicom.sr.coding.Code]
             concept name
         value: Union[int, float], optional
             numeric value
-        unit: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
+        unit: Union[highdicom.sr.CodedConcept, pydicom.sr.coding.Code], optional
             coded units of measurement (see `CID 7181 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_7181.html>`_
             "Abstract Multi-dimensional Image Model Component Units")
-        qualifier: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code], optional
+        qualifier: Union[highdicom.sr.CodedConcept, pydicom.sr.coding.Code], optional
             qualification of numeric value or as an alternative to
             numeric value, e.g., reason for absence of numeric value
             (see `CID 42 <http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_42.html>`_
             "Numeric Value Qualifier" for options)
-        relationship_type: Union[highdicom.sr.enum.RelationshipTypeValues, str], optional
+        relationship_type: Union[highdicom.sr.RelationshipTypeValues, str], optional
             type of relationship with parent content item
 
         Note
@@ -469,7 +469,7 @@ class ContainerContentItem(ContentItem):
         """
         Parameters
         ----------
-        name: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code]
+        name: Union[highdicom.sr.CodedConcept, pydicom.sr.coding.Code]
             concept name
         is_content_continous: bool, optional
             whether contained content items are logically linked in a
@@ -510,13 +510,13 @@ class CompositeContentItem(ContentItem):
         """
         Parameters
         ----------
-        name: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code]
+        name: Union[highdicom.sr.CodedConcept, pydicom.sr.coding.Code]
             concept name
         referenced_sop_class_uid: Union[pydicom.uid.UID, str]
             SOP Class UID of the referenced object
         referenced_sop_instance_uid: Union[pydicom.uid.UID, str]
             SOP Instance UID of the referenced object
-        relationship_type: Union[highdicom.sr.enum.RelationshipTypeValues, str], optional
+        relationship_type: Union[highdicom.sr.RelationshipTypeValues, str], optional
             type of relationship with parent content item
 
         """  # noqa
@@ -551,7 +551,7 @@ class ImageContentItem(ContentItem):
         """
         Parameters
         ----------
-        name: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code]
+        name: Union[highdicom.sr.CodedConcept, pydicom.sr.coding.Code]
             concept name
         referenced_sop_class_uid: Union[pydicom.uid.UID, str]
             SOP Class UID of the referenced image object
@@ -563,7 +563,7 @@ class ImageContentItem(ContentItem):
         referenced_segment_numbers: Union[int, Sequence[int]], optional
             number of segment(s) to which the refernce applies in case of a
             segmentation image
-        relationship_type: Union[highdicom.sr.enum.RelationshipTypeValues, str], optional
+        relationship_type: Union[highdicom.sr.RelationshipTypeValues, str], optional
             type of relationship with parent content item
 
         """  # noqa
@@ -607,22 +607,22 @@ class ScoordContentItem(ContentItem):
         """
         Parameters
         ----------
-        name: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code]
+        name: Union[highdicom.sr.CodedConcept, pydicom.sr.coding.Code]
             concept name
-        graphic_type: Union[highdicom.sr.enum.GraphicTypeValues, str]
+        graphic_type: Union[highdicom.sr.GraphicTypeValues, str]
             name of the graphic type
         graphic_data: numpy.ndarray[numpy.int]
             array of ordered spatial coordinates, where each row of the array
             represents a (column, row) coordinate pair
-        pixel_origin_interpretation: Union[highdicom.sr.enum.PixelOriginInterpretationValues, str]
+        pixel_origin_interpretation: Union[highdicom.sr.PixelOriginInterpretationValues, str]
             whether pixel coordinates specified by `graphic_data` are defined
             relative to the total pixel matrix
-            (``highdicom.sr.enum.PixelOriginInterpretationValues.VOLUME``) or
+            (``highdicom.sr.PixelOriginInterpretationValues.VOLUME``) or
             relative to an individual frame
-            (``highdicom.sr.enum.PixelOriginInterpretationValues.FRAME``)
+            (``highdicom.sr.PixelOriginInterpretationValues.FRAME``)
         fiducial_uid: Union[pydicom.uid.UID, str, None], optional
             unique identifier for the content item
-        relationship_type: Union[highdicom.sr.enum.RelationshipTypeValues, str], optional
+        relationship_type: Union[highdicom.sr.RelationshipTypeValues, str], optional
             type of relationship with parent content item
 
         """  # noqa
@@ -702,9 +702,9 @@ class Scoord3DContentItem(ContentItem):
         """
         Parameters
         ----------
-        name: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code]
+        name: Union[highdicom.sr.CodedConcept, pydicom.sr.coding.Code]
             concept name
-        graphic_type: Union[highdicom.sr.enum.GraphicTypeValues3D, str]
+        graphic_type: Union[highdicom.sr.GraphicTypeValues3D, str]
             name of the graphic type
         graphic_data: numpy.ndarray[numpy.float]
             array of spatial coordinates, where each row of the array
@@ -714,7 +714,7 @@ class Scoord3DContentItem(ContentItem):
             coordinates are defined
         fiducial_uid: str, optional
             unique identifier for the content item
-        relationship_type: Union[highdicom.sr.enum.RelationshipTypeValues, str], optional
+        relationship_type: Union[highdicom.sr.RelationshipTypeValues, str], optional
             type of relationship with parent content item
 
         """  # noqa
@@ -775,9 +775,9 @@ class TcoordContentItem(ContentItem):
         """
         Parameters
         ----------
-        name: Union[highdicom.sr.coding.CodedConcept, pydicom.sr.coding.Code]
+        name: Union[highdicom.sr.CodedConcept, pydicom.sr.coding.Code]
             concept name
-        temporal_range_type: Union[highdicom.sr.enum.TemporalRangeTypeValues, str]
+        temporal_range_type: Union[highdicom.sr.TemporalRangeTypeValues, str]
             name of the temporal range type
         referenced_sample_positions: Sequence[int], optional
             one-based relative sample position of acquired time points
@@ -786,7 +786,7 @@ class TcoordContentItem(ContentItem):
             seconds after start of the acquisition of the time series
         referenced_date_time: Sequence[datetime.datetime], optional
             absolute time points
-        relationship_type: Union[highdicom.sr.enum.RelationshipTypeValues, str], optional
+        relationship_type: Union[highdicom.sr.RelationshipTypeValues, str], optional
             type of relationship with parent content item
 
         """  # noqa

--- a/src/highdicom/sr/value_types.py
+++ b/src/highdicom/sr/value_types.py
@@ -66,7 +66,7 @@ class ContentItem(Dataset):
 
     @property
     def name(self) -> CodedConcept:
-        """CodedConcept: coded name of the content item"""
+        """highdicom.sr.CodedConcept: coded name of the content item"""
         return self.ConceptNameCodeSequence[0]
 
     @property

--- a/src/highdicom/utils.py
+++ b/src/highdicom/utils.py
@@ -103,7 +103,7 @@ def compute_plane_position_tiled_full(
 
     Returns
     -------
-    highdicom.content.PlanePositionSequence
+    highdicom.PlanePositionSequence
         Positon of the plane in the slide coordinate system
 
     Raises
@@ -160,7 +160,7 @@ def compute_plane_position_slide_per_frame(
 
     Returns
     -------
-    List[highdicom.content.PlanePositionSequence]
+    List[highdicom.PlanePositionSequence]
         Plane Position Sequence per frame
 
     Raises

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -2,7 +2,7 @@ from unittest import TestCase
 
 import pytest
 
-from highdicom.content import (
+from highdicom import (
     PixelMeasuresSequence,
     PlaneOrientationSequence,
     PlanePositionSequence,

--- a/tests/test_sc.py
+++ b/tests/test_sc.py
@@ -6,8 +6,8 @@ import pytest
 from pydicom import dcmread
 from pydicom.uid import generate_uid, RLELossless
 
-from highdicom.content import SpecimenDescription
-from highdicom.sc.sop import SCImage
+from highdicom import SpecimenDescription
+from highdicom.sc import SCImage
 
 
 class TestSCImage(unittest.TestCase):

--- a/tests/test_seg.py
+++ b/tests/test_seg.py
@@ -15,23 +15,23 @@ from pydicom.uid import (
     RLELossless,
 )
 
-from highdicom.content import (
+from highdicom import (
     AlgorithmIdentificationSequence,
     PlanePositionSequence,
     PixelMeasuresSequence,
     PlaneOrientationSequence,
 )
 from highdicom.enum import CoordinateSystemNames
-from highdicom.seg.content import (
+from highdicom.seg import (
     DimensionIndexSequence,
     SegmentDescription,
 )
-from highdicom.seg.enum import (
+from highdicom.seg import (
     SegmentAlgorithmTypeValues,
     SegmentsOverlapValues,
     SegmentationTypeValues,
 )
-from highdicom.seg.sop import Segmentation
+from highdicom.seg import Segmentation
 from highdicom.seg.utils import iter_segments
 
 

--- a/tests/test_sr.py
+++ b/tests/test_sr.py
@@ -14,8 +14,8 @@ from pydicom.sr.coding import Code
 from pydicom.uid import generate_uid, UID
 from pydicom.valuerep import DA, DS, DT, TM
 
-from highdicom.sr.coding import CodedConcept
-from highdicom.sr.content import (
+from highdicom.sr import CodedConcept
+from highdicom.sr import (
     FindingSite,
     ImageRegion,
     ImageRegion3D,
@@ -29,14 +29,14 @@ from highdicom.sr.content import (
     SourceSeriesForSegmentation,
     VolumeSurface,
 )
-from highdicom.sr.enum import (
+from highdicom.sr import (
     GraphicTypeValues,
     GraphicTypeValues3D,
     RelationshipTypeValues,
     ValueTypeValues,
 )
 from highdicom.sr.utils import find_content_items
-from highdicom.sr.value_types import (
+from highdicom.sr import (
     CodeContentItem,
     ContainerContentItem,
     CompositeContentItem,
@@ -50,12 +50,12 @@ from highdicom.sr.value_types import (
     TimeContentItem,
     UIDRefContentItem,
 )
-from highdicom.sr.sop import (
+from highdicom.sr import (
     ComprehensiveSR,
     Comprehensive3DSR,
     EnhancedSR,
 )
-from highdicom.sr.templates import (
+from highdicom.sr import (
     AlgorithmIdentification,
     DeviceObserverIdentifyingAttributes,
     Measurement,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,6 @@
 import pytest
 
-from highdicom.content import PlanePositionSequence
+from highdicom import PlanePositionSequence
 from highdicom.enum import CoordinateSystemNames
 from highdicom.utils import compute_plane_position_tiled_full
 


### PR DESCRIPTION
Fixing docstrings and sphinx pages for #70 and setting up this PR to merge into #70. See comments in #70 for why this is necessary. Steps involve:

- Removing all packages whose contents moved "up the tree" from the `package.rst` so their docs are not duplicated.
- Changing all references to these types in the docstrings to use the "higher level" version (with copious `sed -i`) so that hyperlinks in the docs build correctly.

I also fixed an issue in which `highdicom.seg.content` was not included in `highdicom.seg.__init__.py`