### PR TITLE
Person Name Checks

### DIFF
--- a/docs/package.rst
+++ b/docs/package.rst
@@ -59,6 +59,15 @@ highdicom.spatial module
    :undoc-members:
    :show-inheritance:
 
+highdicom.valuerep module
++++++++++++++++++++++++++
+
+.. automodule:: highdicom.valuerep
+   :members:
+   :special-members: __call__
+   :undoc-members:
+   :show-inheritance:
+
 highdicom.utils module
 ++++++++++++++++++++++
 

--- a/src/highdicom/sc/sop.py
+++ b/src/highdicom/sc/sop.py
@@ -9,7 +9,7 @@ from pydicom._storage_sopclass_uids import SecondaryCaptureImageStorage
 from pydicom.dataset import Dataset
 from pydicom.encaps import encapsulate
 from pydicom.sr.codedict import codes
-from pydicom.valuerep import DA, TM
+from pydicom.valuerep import DA, PersonName, TM
 from pydicom.uid import (
     ImplicitVRLittleEndian,
     ExplicitVRLittleEndian,
@@ -32,6 +32,7 @@ from highdicom.enum import (
 from highdicom.frame import encode_frame
 from highdicom.sc.enum import ConversionTypeValues
 from highdicom.sr.coding import CodedConcept
+from highdicom.valuerep import check_person_name
 
 
 logger = logging.getLogger(__name__)
@@ -59,14 +60,14 @@ class SCImage(SOPClass):
             instance_number: int,
             manufacturer: str,
             patient_id: Optional[str] = None,
-            patient_name: Optional[str] = None,
+            patient_name: Optional[Union[str, PersonName]] = None,
             patient_birth_date: Optional[str] = None,
             patient_sex: Optional[str] = None,
             accession_number: Optional[str] = None,
             study_id: str = None,
             study_date: Optional[Union[str, datetime.date]] = None,
             study_time: Optional[Union[str, datetime.time]] = None,
-            referring_physician_name: Optional[str] = None,
+            referring_physician_name: Optional[Union[str, PersonName]] = None,
             pixel_spacing: Optional[Tuple[int, int]] = None,
             laterality: Optional[Union[str, LateralityValues]] = None,
             patient_orientation: Optional[
@@ -126,7 +127,7 @@ class SCImage(SOPClass):
             as `institution_name`)
         patient_id: str, optional
            ID of the patient (medical record number)
-        patient_name: str, optional
+        patient_name: Optional[Union[str, PersonName]], optional
            Name of the patient
         patient_birth_date: str, optional
            Patient's birth date
@@ -140,7 +141,7 @@ class SCImage(SOPClass):
            Date of study creation
         study_time: Union[str, datetime.time], optional
            Time of study creation
-        referring_physician_name: str, optional
+        referring_physician_name: Optional[Union[str, PersonName]], optional
             Name of the referring physician
         pixel_spacing: Tuple[int, int], optional
             Physical spacing in millimeter between pixels along the row and
@@ -181,6 +182,12 @@ class SCImage(SOPClass):
             raise ValueError(
                 f'Transfer syntax "{transfer_syntax_uid}" is not supported'
             )
+
+        # Check names
+        if patient_name is not None:
+            check_person_name(patient_name)
+        if referring_physician_name is not None:
+            check_person_name(referring_physician_name)
 
         super().__init__(
             study_instance_uid=study_instance_uid,

--- a/src/highdicom/seg/sop.py
+++ b/src/highdicom/seg/sop.py
@@ -16,6 +16,7 @@ from pydicom.uid import (
     UID,
 )
 from pydicom.sr.codedict import codes
+from pydicom.valuerep import PersonName
 
 from highdicom.base import SOPClass
 from highdicom.content import (
@@ -35,6 +36,7 @@ from highdicom.seg.enum import (
     SegmentsOverlapValues,
 )
 from highdicom.sr.coding import CodedConcept
+from highdicom.valuerep import check_person_name
 
 
 logger = logging.getLogger(__name__)
@@ -67,7 +69,7 @@ class Segmentation(SOPClass):
             ] = SegmentationFractionalTypeValues.PROBABILITY,
             max_fractional_value: int = 255,
             content_description: Optional[str] = None,
-            content_creator_name: Optional[str] = None,
+            content_creator_name: Optional[Union[str, PersonName]] = None,
             transfer_syntax_uid: Union[str, UID] = ImplicitVRLittleEndian,
             pixel_measures: Optional[PixelMeasuresSequence] = None,
             plane_orientation: Optional[PlaneOrientationSequence] = None,
@@ -143,7 +145,7 @@ class Segmentation(SOPClass):
             a pixel represents a given segment
         content_description: str, optional
             Description of the segmentation
-        content_creator_name: str, optional
+        content_creator_name: Optional[Union[str, PersonName]], optional
             Name of the creator of the segmentation
         transfer_syntax_uid: str, optional
             UID of transfer syntax that should be used for encoding of
@@ -311,6 +313,8 @@ class Segmentation(SOPClass):
         self.PixelRepresentation = 0
         self.ContentLabel = 'ISO_IR 192'  # UTF-8
         self.ContentDescription = content_description
+        if content_creator_name is not None:
+            check_person_name(content_creator_name)
         self.ContentCreatorName = content_creator_name
 
         segmentation_type = SegmentationTypeValues(segmentation_type)

--- a/src/highdicom/sr/sop.py
+++ b/src/highdicom/sr/sop.py
@@ -7,7 +7,7 @@ from typing import Any, Mapping, List, Optional, Sequence, Tuple, Union
 
 from pydicom.dataset import Dataset
 from pydicom.sr.coding import Code
-from pydicom.valuerep import DT
+from pydicom.valuerep import DT, PersonName
 from pydicom._storage_sopclass_uids import (
     ComprehensiveSRStorage,
     Comprehensive3DSRStorage,
@@ -18,6 +18,7 @@ from highdicom.base import SOPClass
 from highdicom.sr.coding import CodedConcept
 from highdicom.sr.enum import ValueTypeValues
 from highdicom.sr.utils import find_content_items
+from highdicom.valuerep import check_person_name
 
 
 logger = logging.getLogger(__name__)
@@ -42,7 +43,7 @@ class _SR(SOPClass):
         is_verified: bool = False,
         institution_name: Optional[str] = None,
         institutional_department_name: Optional[str] = None,
-        verifying_observer_name: Optional[str] = None,
+        verifying_observer_name: Optional[Union[str, PersonName]] = None,
         verifying_organization: Optional[str] = None,
         performed_procedure_codes: Optional[
             Sequence[Union[Code, CodedConcept]]
@@ -90,11 +91,11 @@ class _SR(SOPClass):
         institutional_department_name: str, optional
             Name of the department of the person or device that creates the
             SR document instance
-        verifying_observer_name: Union[str, None], optional
-            Name of the person that verfied the SR document
+        verifying_observer_name: Optional[Union[str, PersonName]], optional
+            Name of the person that verified the SR document
             (required if `is_verified`)
         verifying_organization: str, optional
-            Name of the organization that verfied the SR document
+            Name of the organization that verified the SR document
             (required if `is_verified`)
         performed_procedure_codes: List[highdicom.sr.CodedConcept], optional
             Codes of the performed procedures that resulted in the SR document
@@ -166,6 +167,7 @@ class _SR(SOPClass):
                 )
             self.VerificationFlag = 'VERIFIED'
             observer_item = Dataset()
+            check_person_name(verifying_observer_name)
             observer_item.VerifyingObserverName = verifying_observer_name
             observer_item.VerifyingOrganization = verifying_organization
             observer_item.VerificationDateTime = DT(now)
@@ -371,7 +373,7 @@ class EnhancedSR(_SR):
         is_verified: bool = False,
         institution_name: Optional[str] = None,
         institutional_department_name: Optional[str] = None,
-        verifying_observer_name: Optional[str] = None,
+        verifying_observer_name: Optional[Union[str, PersonName]] = None,
         verifying_organization: Optional[str] = None,
         performed_procedure_codes: Optional[
             Sequence[Union[Code, CodedConcept]]
@@ -417,11 +419,11 @@ class EnhancedSR(_SR):
         institutional_department_name: str, optional
             Name of the department of the person or device that creates the
             SR document instance
-        verifying_observer_name: Union[str, None], optional
-            Name of the person that verfied the SR document
+        verifying_observer_name: Optional[Union[str, PersonName]], optional
+            Name of the person that verified the SR document
             (required if `is_verified`)
         verifying_organization: str, optional
-            Name of the organization that verfied the SR document
+            Name of the organization that verified the SR document
             (required if `is_verified`)
         performed_procedure_codes: List[highdicom.sr.CodedConcept], optional
             Codes of the performed procedures that resulted in the SR document
@@ -499,7 +501,7 @@ class ComprehensiveSR(_SR):
             is_verified: bool = False,
             institution_name: Optional[str] = None,
             institutional_department_name: Optional[str] = None,
-            verifying_observer_name: Optional[str] = None,
+            verifying_observer_name: Optional[Union[str, PersonName]] = None,
             verifying_organization: Optional[str] = None,
             performed_procedure_codes: Optional[
                 Sequence[Union[Code, CodedConcept]]
@@ -545,11 +547,11 @@ class ComprehensiveSR(_SR):
         institutional_department_name: str, optional
             Name of the department of the person or device that creates the
             SR document instance
-        verifying_observer_name: Union[str, None], optional
-            Name of the person that verfied the SR document
+        verifying_observer_name: Optional[Union[str, PersonName]], optional
+            Name of the person that verified the SR document
             (required if `is_verified`)
         verifying_organization: str, optional
-            Name of the organization that verfied the SR document
+            Name of the organization that verified the SR document
             (required if `is_verified`)
         performed_procedure_codes: List[highdicom.sr.CodedConcept], optional
             Codes of the performed procedures that resulted in the SR document
@@ -627,7 +629,7 @@ class Comprehensive3DSR(_SR):
             is_verified: bool = False,
             institution_name: Optional[str] = None,
             institutional_department_name: Optional[str] = None,
-            verifying_observer_name: Optional[str] = None,
+            verifying_observer_name: Optional[Union[str, PersonName]] = None,
             verifying_organization: Optional[str] = None,
             performed_procedure_codes: Optional[
                 Sequence[Union[Code, CodedConcept]]
@@ -673,11 +675,11 @@ class Comprehensive3DSR(_SR):
         institutional_department_name: str, optional
             Name of the department of the person or device that creates the
             SR document instance
-        verifying_observer_name: Union[str, None], optional
-            Name of the person that verfied the SR document
+        verifying_observer_name: Optional[Union[str, PersonName]], optional
+            Name of the person that verified the SR document
             (required if `is_verified`)
         verifying_organization: str, optional
-            Name of the organization that verfied the SR document
+            Name of the organization that verified the SR document
             (required if `is_verified`)
         performed_procedure_codes: List[highdicom.sr.CodedConcept], optional
             Codes of the performed procedures that resulted in the SR document

--- a/src/highdicom/sr/sop.py
+++ b/src/highdicom/sr/sop.py
@@ -91,7 +91,7 @@ class _SR(SOPClass):
         institutional_department_name: str, optional
             Name of the department of the person or device that creates the
             SR document instance
-        verifying_observer_name: Optional[Union[str, PersonName]], optional
+        verifying_observer_name: Union[str, pydicom.valuerep.PersonName, None], optional
             Name of the person that verified the SR document
             (required if `is_verified`)
         verifying_organization: str, optional
@@ -419,7 +419,7 @@ class EnhancedSR(_SR):
         institutional_department_name: str, optional
             Name of the department of the person or device that creates the
             SR document instance
-        verifying_observer_name: Optional[Union[str, PersonName]], optional
+        verifying_observer_name: Union[str, pydicom.valuerep.PersonName, None], optional
             Name of the person that verified the SR document
             (required if `is_verified`)
         verifying_organization: str, optional
@@ -547,7 +547,7 @@ class ComprehensiveSR(_SR):
         institutional_department_name: str, optional
             Name of the department of the person or device that creates the
             SR document instance
-        verifying_observer_name: Optional[Union[str, PersonName]], optional
+        verifying_observer_name: Union[str, pydicom.valuerep.PersonName, None], optional
             Name of the person that verified the SR document
             (required if `is_verified`)
         verifying_organization: str, optional
@@ -675,7 +675,7 @@ class Comprehensive3DSR(_SR):
         institutional_department_name: str, optional
             Name of the department of the person or device that creates the
             SR document instance
-        verifying_observer_name: Optional[Union[str, PersonName]], optional
+        verifying_observer_name: Union[str, pydicom.valuerep.PersonName, None], optional
             Name of the person that verified the SR document
             (required if `is_verified`)
         verifying_organization: str, optional

--- a/src/highdicom/sr/templates.py
+++ b/src/highdicom/sr/templates.py
@@ -23,6 +23,7 @@ from highdicom.sr.value_types import (
     ContentItem,
     ContentSequence,
     NumContentItem,
+    PnameContentItem,
     TextContentItem,
     UIDRefContentItem,
 )
@@ -529,7 +530,7 @@ class PersonObserverIdentifyingAttributes(Template):
 
         """  # noqa
         super().__init__()
-        name_item = TextContentItem(
+        name_item = PnameContentItem(
             name=CodedConcept(
                 value='121008',
                 meaning='Person Observer Name',

--- a/src/highdicom/sr/value_types.py
+++ b/src/highdicom/sr/value_types.py
@@ -18,6 +18,7 @@ from highdicom.sr.enum import (
     TemporalRangeTypeValues,
     ValueTypeValues,
 )
+from highdicom.valuerep import check_person_name
 
 
 class ContentItem(Dataset):
@@ -231,6 +232,7 @@ class PnameContentItem(ContentItem):
         super(PnameContentItem, self).__init__(
             ValueTypeValues.PNAME, name, relationship_type
         )
+        check_person_name(value)
         self.PersonName = PersonName(value)
 
 

--- a/src/highdicom/valuerep.py
+++ b/src/highdicom/valuerep.py
@@ -1,0 +1,59 @@
+"""Functions for working with DICOM value representations."""
+from typing import Union
+
+from pydicom.valuerep import PersonName
+
+
+def check_person_name(person_name: Union[str, PersonName]) -> None:
+    """Check for potential problems with person name strings.
+
+    The DICOM Person Name (PN) value representation has a specific format
+    with multiple components (family name, given name, middle name, prefix,
+    suffix) separated by caret characters ('^'), where any number of components
+    and their caret separators may be missing. Unfortunately it is both easy to
+    make mistake when constructing names with this format, and impossible to
+    check for certain whether it has been done correctly.
+
+    This function checks for strings representing person names that have a high
+    likelihood of having been encoded incorrectly and raises an exception if
+    such a case is found.
+
+    A string is considered to be an invalid person name if it contains no caret
+    characters.
+
+    Note
+    ----
+    A name consisting of only a family name component is valid
+    according to the standard but will be disallowed by this function. However
+    if necessary, such a name can be still be encoded by adding a trailing
+    caret character to disambiguate the meaning.
+
+    Parameters
+    ----------
+    person_name: Union[str, pydicom.valuerep.PersonName]
+        Name to check.
+
+    Raises
+    ------
+    ValueError
+        If the provided value is highly likely to be an invalid person name.
+    TypeError
+        If the provided person name has an invalid type.
+
+    """
+    if not isinstance(person_name, (str, PersonName)):
+        raise TypeError('Invalid type for a person name.')
+
+    name_url = (
+        'http://dicom.nema.org/dicom/2013/output/chtml/part05/'
+        'sect_6.2.html#sect_6.2.1.2'
+    )
+    if '^' not in person_name:
+        raise ValueError(
+            f'The string "{person_name}" is unlikely to represent the '
+            'intended person name since it contains only a single component. '
+            'Construct a person name according to the format in described '
+            f'in {name_url}, or, in pydicom 2.2.0 or later, use the '
+            'pydicom.valuerep.PersonName.from_named_components() method '
+            'to construct the person name correctly.'
+        )

--- a/src/highdicom/valuerep.py
+++ b/src/highdicom/valuerep.py
@@ -5,14 +5,14 @@ from pydicom.valuerep import PersonName
 
 
 def check_person_name(person_name: Union[str, PersonName]) -> None:
-    """Check for potential problems with person name strings.
+    """Check for problems with person name strings.
 
-    The DICOM Person Name (PN) value representation has a specific format
-    with multiple components (family name, given name, middle name, prefix,
-    suffix) separated by caret characters ('^'), where any number of components
-    and their caret separators may be missing. Unfortunately it is both easy to
-    make mistake when constructing names with this format, and impossible to
-    check for certain whether it has been done correctly.
+    The DICOM Person Name (PN) value representation has a specific format with
+    multiple components (family name, given name, middle name, prefix, suffix)
+    separated by caret characters ('^'), where any number of components may be
+    missing and trailing caret separators may be omitted. Unfortunately it is
+    both easy to make a mistake when constructing names with this format, and
+    impossible to check for certain whether it has been done correctly.
 
     This function checks for strings representing person names that have a high
     likelihood of having been encoded incorrectly and raises an exception if
@@ -23,10 +23,10 @@ def check_person_name(person_name: Union[str, PersonName]) -> None:
 
     Note
     ----
-    A name consisting of only a family name component is valid
-    according to the standard but will be disallowed by this function. However
-    if necessary, such a name can be still be encoded by adding a trailing
-    caret character to disambiguate the meaning.
+    A name consisting of only a family name component (e.g. ``'Bono'``) is
+    valid according to the standard but will be disallowed by this function.
+    However if necessary, such a name can be still be encoded by adding a
+    trailing caret character to disambiguate the meaning (e.g. ``'Bono^'``).
 
     Parameters
     ----------
@@ -55,5 +55,7 @@ def check_person_name(person_name: Union[str, PersonName]) -> None:
             'Construct a person name according to the format in described '
             f'in {name_url}, or, in pydicom 2.2.0 or later, use the '
             'pydicom.valuerep.PersonName.from_named_components() method '
-            'to construct the person name correctly.'
+            'to construct the person name correctly. If a single-component '
+            'name is really intended, add a trailing caret character to '
+            'disambiguate the name.'
         )

--- a/tests/test_seg.py
+++ b/tests/test_seg.py
@@ -1467,7 +1467,7 @@ class TestSegmentation(unittest.TestCase):
         fractional_type = 'OCCUPANCY'
         max_fractional_value = 100
         content_description = 'bla bla bla'
-        content_creator_name = 'Me Myself'
+        content_creator_name = 'Family^Given'
         series_description = 'My First Segmentation'
         instance = Segmentation(
             source_images=[self._ct_image],

--- a/tests/test_valuerep.py
+++ b/tests/test_valuerep.py
@@ -1,0 +1,44 @@
+import pytest
+
+from pydicom.valuerep import PersonName
+from highdicom.valuerep import check_person_name
+
+
+test_names = [
+    'Doe^John',
+    'Doe^John^^Mr',
+    'Doe^',
+    '山田^太郎',
+    '洪^吉洞'
+]
+
+
+invalid_test_names = [
+    'John Doe',
+    'Mr John Doe',
+    'Doe',
+    '山田太郎',
+    '洪吉洞'
+]
+
+
+@pytest.mark.parametrize('name', test_names)
+def test_valid_strings(name):
+    check_person_name(name)
+
+
+@pytest.mark.parametrize('name', test_names)
+def test_valid_person_names(name):
+    check_person_name(PersonName(name))
+
+
+@pytest.mark.parametrize('name', invalid_test_names)
+def test_invalid_strings(name):
+    with pytest.raises(ValueError):
+        check_person_name(name)
+
+
+@pytest.mark.parametrize('name', invalid_test_names)
+def test_invalid_person_names(name):
+    with pytest.raises(ValueError):
+        check_person_name(PersonName(name))


### PR DESCRIPTION
As described and discussed in #56, how to construct DICOM PersonNames correctly is not obvious and currently highdicom provides no guidance on how to do this correctly nor checks on strings provided as name parameters through the API. Part of the solution was to add a new constructor method in pydicom (see [pydicom#1331](https://github.com/pydicom/pydicom/pull/1331)) to simplify construction called `PersonName.from_named_components()`. This PR makes some changes on the highdicom side to close #56.

Specifically:
- A check for incorrect person names has been added in a new module `higidicom.valuerep`. This cannot be perfect, but will catch the very common case of people just supplying names with no formatting applied at all. If this check fails, it raises an exception with a useful error message that contains references about how to construct person names correctly and points to the new pydicom constructor (even though at the time or writing that change has still not been released in pydicom)
- Add calls to the check wherever a person name is passed to the highdicom API.
- Tweak the API such that wherever a parameter is passed that ultimately gets encoded as a PersonName, a `pydicom.value.PersonName` may be passed (previously this was allowed in some places but not others). This means that users can always use the new `PersonName` constructor.