### PR TITLE
Add citation to readme and sphinx

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,24 @@
 # High DICOM
 
 A library that provides high-level DICOM abstractions for the Python programming language to facilitate the creation and handling of DICOM objects for image-derived information, including image annotations and image analysis results.
+It currently provides tools for creating and decoding the following DICOM information object definitions (IODs):
+* Segmentation images
+* Structured Reports
+* Secondary Capture images
+* Legacy Converted Enhanced CT/PET/MR images (e.g. for single frame to multi-frame conversion)
 
 ## Documentation
 
 Please refer to the online documentation at [highdicom.readthedocs.io](https://highdicom.readthedocs.io), which includes installation instructions, a user guide with examples, a developer guide, and complete documentation of the application programming interface of the `highdicom` package.
+
+## Citation
+
+For more information about the motivation of the library and the design of highdicom's API, please see the following article:
+
+> [Highdicom: A Python library for standardized encoding of image annotations and machine learning model outputs in pathology and radiology](https://arxiv.org/abs/2106.07806)
+> C.P. Bridge, C. Gorman, S. Pieper, S.W. Doyle, J.K. Lennerz, J. Kalpathy-Cramer, D.A. Clunie, A.Y. Fedorov, and M.D. Herrmann
+
+If you use highdicom in your research, please cite the above article.
 
 ## Support
 

--- a/docs/citation.rst
+++ b/docs/citation.rst
@@ -1,0 +1,11 @@
+.. _citation:
+
+Citation
+========
+
+The following article describes in detail the motivation for creating the *highdicom* library, the design goals of the library, and experiments demonstrating the library's capabilities.
+If you use *highdicom* in research, please cite this article.
+
+    `Highdicom: A Python library for standardized encoding of image annotations and machine learning model outputs in pathology and radiology <https://arxiv.org/abs/2106.07806>`_.
+    C.P. Bridge, C. Gorman, S. Pieper, S.W. Doyle, J.K. Lennerz, J. Kalpathy-Cramer, D.A. Clunie, A.Y. Fedorov, and M.D. Herrmann.
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,6 +10,7 @@ Documentation of the highdicom package
    usage
    development
    conformance
+   citation
    license
    package
 


### PR DESCRIPTION
Added the manuscript link to the project's README and the sphinx documentation, with a request to cite it.

Also added a list of supported IODs to the README so that it's a bit clearer what the library actually does when you land on the github page.