### PR TITLE
Fixes to dimension indices

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,6 +13,7 @@ Documentation of the highdicom package
    citation
    license
    package
+   release_notes
 
 
 

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -7,6 +7,8 @@ Brief release notes may be found on `on Github
 <https://github.com/MGHComputationalPathology/highdicom/releases>`_. This page
 contains migration notes for major breaking changes to the library's API.
 
+.. _add-segments-deprecation:
+
 Deprecation of `add_segments` method
 ------------------------------------
 
@@ -15,13 +17,13 @@ Prior to highdicom 0.8.0, it was possible to add further segments to
 `add_segments` method. This was found to produce incorrect Dimension Index
 Values if the empty frames did not match within all segments added.
 
-To create the DimensionIndexValues correctly, the constructor needs access to
-all segments in the image when it is first created. In highdicom 0.8.0, the
-`add_segments` method was removed. Instead, in highdicom 0.8.0 and later,
-multiple segments can be passed to the constructor by stacking their arrays
-along the fourth dimension.
+To create the Dimension Index Values correctly, the constructor needs access to
+all segments in the image when it is first created. Therefore, the
+`add_segments` method was removed in highdicom 0.8.0. Instead, in highdicom
+0.8.0 and later, multiple segments can be passed to the constructor by stacking
+their arrays along the fourth dimension.
 
-Given code that adds segments like this:
+Given code that adds segments like this, in highdicom 0.7.0 and earlier:
 
 .. code-block:: python
 
@@ -59,7 +61,7 @@ Given code that adds segments like this:
 
 
 This can be migrated to highdicom 0.8.0 and later by concatenating the arrays
-along the fourth dimension.
+along the fourth dimension and calling the constructor at the end.
 
 .. code-block:: python
 

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,0 +1,99 @@
+.. _releasenotes:
+
+Release Notes
+=============
+
+Brief release notes may be found on `on Github
+<https://github.com/MGHComputationalPathology/highdicom/releases>`_. This page
+contains migration notes for major breaking changes to the library's API.
+
+Deprecation of `add_segments` method
+------------------------------------
+
+Prior to highdicom 0.8.0, it was possible to add further segments to
+:class:`highdicom.seg.Segmentation` image after its construction using the
+`add_segments` method. This was found to produce incorrect Dimension Index
+Values if the empty frames did not match within all segments added.
+
+To create the DimensionIndexValues correctly, the constructor needs access to
+all segments in the image when it is first created. In highdicom 0.8.0, the
+`add_segments` method was removed. Instead, in highdicom 0.8.0 and later,
+multiple segments can be passed to the constructor by stacking their arrays
+along the fourth dimension.
+
+Given code that adds segments like this:
+
+.. code-block:: python
+
+    import numpy as np
+    import highdicom as hd
+
+    # Create initial segment mask and description
+    mask_1 = np.array(
+        # ...
+    )
+    description_1 = hd.seg.SegmentDescription(
+        # ...
+    )
+    seg = hd.seg.Segmentation(
+        # ...
+        pixel_array=mask_1,
+        segment_descriptions=[description_1],
+        # ...
+    )
+
+    # Create a second segment and add to the existing segmentation
+    mask_2 = np.array(
+        # ...
+    )
+    description_2 = hd.seg.SegmentDescription(
+        # ...
+    )
+
+    seg.add_segments(
+        # ...
+        pixel_array=mask_2,
+        segment_descriptions=[description_2],
+        # ...
+    )
+
+
+This can be migrated to highdicom 0.8.0 and later by concatenating the arrays
+along the fourth dimension.
+
+.. code-block:: python
+
+    import numpy as np
+    import highdicom as hd
+
+    # Create initial segment mask and description
+    mask_1 = np.array(
+        # ...
+    )
+    description_1 = hd.seg.SegmentDescription(
+        # ...
+    )
+
+    # Create a second segment and description
+    mask_2 = np.array(
+        # ...
+    )
+    description_2 = hd.seg.SegmentDescription(
+        # ...
+    )
+
+    combined_segments = np.concatenate([mask_1, mask_2], axis=-1)
+    combined_descriptions = [description_1, description_2]
+
+    seg = hd.seg.Segmentation(
+        # ...
+        pixel_array=combined_segments,
+        segment_descriptions=combined_descriptions,
+        # ...
+    )
+
+
+Note that segments must always be stacked down the fourth dimension (with index
+3) of the ``pixel_array``. In order to create a segmentation with multiple
+segments for a single source frame, it is required to add a new dimension
+(with length 1) as the first dimension (index 0) of the array.

--- a/src/highdicom/seg/content.py
+++ b/src/highdicom/seg/content.py
@@ -180,7 +180,7 @@ class DimensionIndexSequence(DataElementSequence):
         super().__init__()
         self._coordinate_system = CoordinateSystemNames(coordinate_system)
         if self._coordinate_system == CoordinateSystemNames.SLIDE:
-            dim_uid = '1.2.826.0.1.3680043.9.7433.2.4'
+            dim_uid = UID()
 
             segment_number_index = Dataset()
             segment_number_index.DimensionIndexPointer = tag_for_keyword(
@@ -261,7 +261,7 @@ class DimensionIndexSequence(DataElementSequence):
             ])
 
         elif self._coordinate_system == CoordinateSystemNames.PATIENT:
-            dim_uid = '1.2.826.0.1.3680043.9.7433.2.3'
+            dim_uid = UID()
 
             segment_number_index = Dataset()
             segment_number_index.DimensionIndexPointer = tag_for_keyword(

--- a/src/highdicom/seg/content.py
+++ b/src/highdicom/seg/content.py
@@ -14,6 +14,7 @@ from highdicom.content import (
 from highdicom.enum import CoordinateSystemNames
 from highdicom.seg.enum import SegmentAlgorithmTypeValues
 from highdicom.sr.coding import CodedConcept
+from highdicom.uid import UID
 from highdicom.utils import compute_plane_position_slide_per_frame
 
 

--- a/src/highdicom/seg/sop.py
+++ b/src/highdicom/seg/sop.py
@@ -982,7 +982,7 @@ class Segmentation(SOPClass):
         plane_positions: Optional[Sequence[PlanePositionSequence]] = None,
         omit_empty_frames: bool = True,
     ) -> None:
-        raise NotImplementedError(
+        raise AttributeError(
             'To ensure correctness of segmentation images, the add_segments '
             'method was deprecated in highdicom 0.8.0. For more information '
             'and migration instructions visit '

--- a/src/highdicom/seg/sop.py
+++ b/src/highdicom/seg/sop.py
@@ -2,12 +2,11 @@
 import logging
 import numpy as np
 from collections import defaultdict
-from typing import Any, Dict, List, Optional, Set, Sequence, Union, Tuple
+from typing import Any, Dict, List, Optional, Sequence, Union, Tuple
 
 from pydicom.dataset import Dataset
-from pydicom.encaps import decode_data_sequence, encapsulate
+from pydicom.encaps import encapsulate
 from pydicom.pixel_data_handlers.numpy_handler import pack_bits
-from pydicom.pixel_data_handlers.util import get_expected_length
 from pydicom.uid import (
     ExplicitVRLittleEndian,
     ImplicitVRLittleEndian,
@@ -772,7 +771,9 @@ class Segmentation(SOPClass):
                         )
                     else:
                         # Multiple single-frame source images
-                        src_img_item = self.SourceImageSequence[source_image_index]
+                        src_img_item = self.SourceImageSequence[
+                            source_image_index
+                        ]
                     derivation_src_img_item.ReferencedSOPClassUID = \
                         src_img_item.ReferencedSOPClassUID
                     derivation_src_img_item.ReferencedSOPInstanceUID = \

--- a/src/highdicom/seg/sop.py
+++ b/src/highdicom/seg/sop.py
@@ -891,7 +891,7 @@ class Segmentation(SOPClass):
         plane_positions: Optional[Sequence[PlanePositionSequence]] = None,
         omit_empty_frames: bool = True,
     ) -> None:
-        raise DeprecationWarning(
+        raise NotImplementedError(
             'To ensure correctness of segmentation images, the add_segments '
             'method was deprecated in highdicom 0.8.0. For more information '
             'and migration instructions visit '

--- a/src/highdicom/seg/sop.py
+++ b/src/highdicom/seg/sop.py
@@ -895,5 +895,6 @@ class Segmentation(SOPClass):
             'To ensure correctness of segmentation images, the add_segments '
             'method was deprecated in highdicom 0.8.0. For more information '
             'and migration instructions visit '
-            'https://highdicom.readthedocs.io/en/latest/???????'  # TODO
+            'https://highdicom.readthedocs.io/en/latest/release_notes.html'
+            '#deprecation-of-add-segments-method'
         )

--- a/src/highdicom/seg/sop.py
+++ b/src/highdicom/seg/sop.py
@@ -758,7 +758,12 @@ class Segmentation(SOPClass):
 
             contained_plane_index = []
             for j in plane_sort_index:
+                # Index of this frame in the original list of source indices
                 source_image_index = source_image_indices[j]
+
+                # Even though fully-empty slices were removed earlier, 
+                # there may still be slices in which this segment is
+                # absent. Such frames should be removed
                 if np.sum(planes[j]) == 0:
                     logger.info(
                         'skip empty plane {} of segment #{}'.format(

--- a/src/highdicom/seg/sop.py
+++ b/src/highdicom/seg/sop.py
@@ -96,28 +96,26 @@ class Segmentation(SOPClass):
             single 3D multi-frame image (such as a multi-frame CT/MR image), or
             a single 2D tiled image (such as a slide microscopy image).
 
-            If `pixel_array` represents the segmentation of a 3D image, the
-            first dimension represents individual 2D planes and these planes
-            must be ordered based on their position in the three-dimensional
-            patient coordinate system (first along the X axis, second along the
-            Y axis, and third along the Z axis).
+            If ``pixel_array`` represents the segmentation of a 3D image, the
+            first dimension represents individual 2D planes. Unless the
+            ``plane_positions`` parameter is provided, the frame in
+            ``pixel_array[i, ...]`` should correspond to either
+            ``source_images[i]`` (if ``source_images`` is a list of single
+            frame instances) or source_images[0].pixel_array[i, ...] if
+            ``source_images`` is a single multiframe instance.
 
-            If `pixel_array` is a 3D array representing the segmentation of a
-            tiled 2D image, the first dimension represents individual 2D tiles
-            (for one channel and z-stack) and these tiles must be ordered based
-            on their position in the tiled total pixel matrix (first along the
-            row dimension and second along the column dimension, which are
-            defined in the three-dimensional slide coordinate system by the
-            direction cosines encoded by the *Image Orientation (Slide)*
-            attribute).
+            Similarly, if ``pixel_array`` is a 3D array representing the
+            segmentation of a tiled 2D image, the first dimension represents
+            individual 2D tiles (for one channel and z-stack) and these tiles
+            correspond to the frames in the source image dataset.
 
-            If `pixel_array` is an unsigned integer or boolean array with
+            If ``pixel_array`` is an unsigned integer or boolean array with
             binary data (containing only the values ``True`` and ``False`` or
             ``0`` and ``1``) or a floating-point array, it represents a single
             segment. In the case of a floating-point array, values must be in
             the range 0.0 to 1.0.
 
-            Otherwise, if `pixel_array` is a 2D or 3D array containing multiple
+            Otherwise, if ``pixel_array`` is a 2D or 3D array containing multiple
             unsigned integer values, each value is treated as a different
             segment whose segment number is that integer value. This is
             referred to as a *label map* style segmentation.  In this case, all
@@ -130,7 +128,7 @@ class Segmentation(SOPClass):
             single frame along the first dimension may be used interchangeably
             as segmentations of a single frame, regardless of their data type.
 
-            If `pixel_array` is a 4D numpy array, the first three dimensions
+            If ``pixel_array`` is a 4D numpy array, the first three dimensions
             are used in the same way as the 3D case and the fourth dimension
             represents multiple segments. In this case
             ``pixel_array[:, :, :, i]`` represents segment number ``i + 1``
@@ -478,7 +476,7 @@ class Segmentation(SOPClass):
         if pixel_array.ndim == 2:
             pixel_array = pixel_array[np.newaxis, ...]
         if pixel_array.ndim not in [3, 4]:
-            raise ValueError('Pixel array must be a 2D, 3D,or 4D array.')
+            raise ValueError('Pixel array must be a 2D, 3D, or 4D array.')
 
         if pixel_array.shape[1:3] != (self.Rows, self.Columns):
             raise ValueError(
@@ -619,6 +617,8 @@ class Segmentation(SOPClass):
         if omit_empty_frames:
             non_empty_frames = []
             non_empty_plane_positions = []
+
+            # This list tracks which source image each non-empty frame came from
             source_image_indices = []
             for i, (frm, pos) in enumerate(zip(pixel_array, plane_positions)):
                 if frm.sum() > 0:

--- a/src/highdicom/seg/sop.py
+++ b/src/highdicom/seg/sop.py
@@ -982,6 +982,11 @@ class Segmentation(SOPClass):
         plane_positions: Optional[Sequence[PlanePositionSequence]] = None,
         omit_empty_frames: bool = True,
     ) -> None:
+        """To ensure correctness of segmentation images, this
+        method was deprecated in highdicom 0.8.0. For more information
+        and migration instructions see :ref:`here <add-segments-deprecation>`.
+
+        """  # noqa E510
         raise AttributeError(
             'To ensure correctness of segmentation images, the add_segments '
             'method was deprecated in highdicom 0.8.0. For more information '

--- a/tests/test_seg.py
+++ b/tests/test_seg.py
@@ -647,20 +647,18 @@ class TestSegmentation(unittest.TestCase):
                 old_v = index_mapping[k][0]
         else:
             # Build up the mapping from index to value
-            for kw in [
-                #'ColumnPositionInTotalImagePixelMatrix',
-                #'RowPositionInTotalImagePixelMatrix'
-                'XOffsetInSlideCoordinateSystem',
-                'YOffsetInSlideCoordinateSystem'
-            ]:
+            for dim_kw, dim_ind in zip([
+                'ColumnPositionInTotalImagePixelMatrix',
+                'RowPositionInTotalImagePixelMatrix'
+            ], [1, 2]):
                 index_mapping = defaultdict(list)
                 for f in seg.PerFrameFunctionalGroupsSequence:
                     content_item = f.FrameContentSequence[0]
-                    posn_index = content_item.DimensionIndexValues[1]
+                    posn_index = content_item.DimensionIndexValues[dim_ind]
                     # This is not general, but all the tests run here use axial
                     # images so just check the z coordinate
                     posn_item = f.PlanePositionSlideSequence[0]
-                    posn_val = getattr(posn_item, kw)
+                    posn_val = getattr(posn_item, dim_kw)
                     index_mapping[posn_index].append(posn_val)
 
                 # Check that each index value found references a unique value

--- a/tests/test_seg.py
+++ b/tests/test_seg.py
@@ -1449,6 +1449,88 @@ class TestSegmentation(unittest.TestCase):
                 expected_encoding
             )
 
+    def test_construction_empty_source_image(self):
+        with pytest.raises(ValueError):
+            Segmentation(
+                source_images=[],  # empty
+                pixel_array=self._ct_pixel_array,
+                segmentation_type=SegmentationTypeValues.FRACTIONAL.value,
+                segment_descriptions=(
+                    self._segment_descriptions
+                ),
+                series_instance_uid=self._series_instance_uid,
+                series_number=self._series_number,
+                sop_instance_uid=self._sop_instance_uid,
+                instance_number=self._instance_number,
+                manufacturer=self._manufacturer,
+                manufacturer_model_name=self._manufacturer_model_name,
+                software_versions=self._software_versions,
+                device_serial_number=self._device_serial_number
+            )
+
+    def test_construction_mixed_source_series(self):
+        with pytest.raises(ValueError):
+            Segmentation(
+                source_images=self._ct_series + [self._ct_image],
+                pixel_array=self._ct_pixel_array,
+                segmentation_type=SegmentationTypeValues.FRACTIONAL.value,
+                segment_descriptions=(
+                    self._additional_segment_descriptions  # seg num 2
+                ),
+                series_instance_uid=self._series_instance_uid,
+                series_number=self._series_number,
+                sop_instance_uid=self._sop_instance_uid,
+                instance_number=self._instance_number,
+                manufacturer=self._manufacturer,
+                manufacturer_model_name=self._manufacturer_model_name,
+                software_versions=self._software_versions,
+                device_serial_number=self._device_serial_number
+            )
+
+    def test_construction_wrong_number_of_segments(self):
+        with pytest.raises(ValueError):
+            Segmentation(
+                source_images=[self._ct_image],
+                pixel_array=self._ct_pixel_array[..., np.newaxis],
+                segmentation_type=SegmentationTypeValues.FRACTIONAL.value,
+                segment_descriptions=(
+                    self._both_segment_descriptions
+                ),
+                series_instance_uid=self._series_instance_uid,
+                series_number=self._series_number,
+                sop_instance_uid=self._sop_instance_uid,
+                instance_number=self._instance_number,
+                manufacturer=self._manufacturer,
+                manufacturer_model_name=self._manufacturer_model_name,
+                software_versions=self._software_versions,
+                device_serial_number=self._device_serial_number
+            )
+
+    def test_construction_stacked_label_map(self):
+        # A 4D integer cannot have non-binary values
+        mask = np.zeros(
+            (1, self._ct_image.Rows, self._ct_image.Columns, 2),
+            dtype=np.uint8
+        )
+        mask[0, 0, 0, 0] = 2  # disallowed
+        with pytest.raises(ValueError):
+            Segmentation(
+                source_images=[self._ct_image],
+                pixel_array=mask,
+                segmentation_type=SegmentationTypeValues.BINARY.value,
+                segment_descriptions=(
+                    self._both_segment_descriptions
+                ),
+                series_instance_uid=self._series_instance_uid,
+                series_number=self._series_number,
+                sop_instance_uid=self._sop_instance_uid,
+                instance_number=self._instance_number,
+                manufacturer=self._manufacturer,
+                manufacturer_model_name=self._manufacturer_model_name,
+                software_versions=self._software_versions,
+                device_serial_number=self._device_serial_number
+            )
+
     def test_construction_segment_numbers_start_wrong(self):
         with pytest.raises(ValueError):
             Segmentation(
@@ -1457,6 +1539,66 @@ class TestSegmentation(unittest.TestCase):
                 segmentation_type=SegmentationTypeValues.FRACTIONAL.value,
                 segment_descriptions=(
                     self._additional_segment_descriptions  # seg num 2
+                ),
+                series_instance_uid=self._series_instance_uid,
+                series_number=self._series_number,
+                sop_instance_uid=self._sop_instance_uid,
+                instance_number=self._instance_number,
+                manufacturer=self._manufacturer,
+                manufacturer_model_name=self._manufacturer_model_name,
+                software_versions=self._software_versions,
+                device_serial_number=self._device_serial_number
+            )
+
+    def test_construction_empty_invalid_floats(self):
+        # Floats outside the range 0.0 to 1.0 are invalid
+        with pytest.raises(ValueError):
+            Segmentation(
+                source_images=[self._ct_image],  # empty
+                pixel_array=self._ct_pixel_array.astype(np.float_) * 2,
+                segmentation_type=SegmentationTypeValues.FRACTIONAL.value,
+                segment_descriptions=(
+                    self._segment_descriptions
+                ),
+                series_instance_uid=self._series_instance_uid,
+                series_number=self._series_number,
+                sop_instance_uid=self._sop_instance_uid,
+                instance_number=self._instance_number,
+                manufacturer=self._manufacturer,
+                manufacturer_model_name=self._manufacturer_model_name,
+                software_versions=self._software_versions,
+                device_serial_number=self._device_serial_number
+            )
+
+    def test_construction_empty_invalid_floats_binary(self):
+        # Cannot use floats other than 0.0 and 1.0 when encoding as BINARY
+        with pytest.raises(ValueError):
+            Segmentation(
+                source_images=[self._ct_image],
+                pixel_array=self._ct_pixel_array.astype(np.float_) * 0.5,
+                segmentation_type=SegmentationTypeValues.BINARY.value,
+                segment_descriptions=(
+                    self._segment_descriptions
+                ),
+                series_instance_uid=self._series_instance_uid,
+                series_number=self._series_number,
+                sop_instance_uid=self._sop_instance_uid,
+                instance_number=self._instance_number,
+                manufacturer=self._manufacturer,
+                manufacturer_model_name=self._manufacturer_model_name,
+                software_versions=self._software_versions,
+                device_serial_number=self._device_serial_number
+            )
+
+    def test_construction_empty_invalid_dtype(self):
+        # Cannot use signed integers
+        with pytest.raises(TypeError):
+            Segmentation(
+                source_images=[self._ct_image],
+                pixel_array=self._ct_pixel_array.astype(np.int16),
+                segmentation_type=SegmentationTypeValues.BINARY.value,
+                segment_descriptions=(
+                    self._segment_descriptions
                 ),
                 series_instance_uid=self._series_instance_uid,
                 series_number=self._series_number,

--- a/tests/test_seg.py
+++ b/tests/test_seg.py
@@ -616,7 +616,7 @@ class TestSegmentation(unittest.TestCase):
 
     @staticmethod
     def check_dimension_index_vals(seg):
-        # Function to apply some checks (necessary but not sufficient for 
+        # Function to apply some checks (necessary but not sufficient for
         # correctness) to ensure that the dimension indices are correct
         is_patient_coord_system = hasattr(
             seg.PerFrameFunctionalGroupsSequence[0],

--- a/tests/test_seg.py
+++ b/tests/test_seg.py
@@ -681,6 +681,13 @@ class TestSegmentation(unittest.TestCase):
         assert len(frame_item.PlanePositionSequence) == 1
         frame_content_item = frame_item.FrameContentSequence[0]
         assert len(frame_content_item.DimensionIndexValues) == 2
+        for i, frame_item in enumerate(
+            instance.PerFrameFunctionalGroupsSequence, 1
+        ):
+            frame_content_item = frame_item.FrameContentSequence[0]
+            # The slice location index values should be consecutive, starting
+            # at 1
+            assert frame_content_item.DimensionIndexValues[1] == i
         for derivation_image_item in frame_item.DerivationImageSequence:
             assert len(derivation_image_item.SourceImageSequence) == 1
         assert SegmentsOverlapValues[instance.SegmentsOverlap] == \
@@ -799,6 +806,13 @@ class TestSegmentation(unittest.TestCase):
         assert len(frame_item.DerivationImageSequence) == 1
         assert len(frame_item.PlanePositionSequence) == 1
         frame_content_item = frame_item.FrameContentSequence[0]
+        for i, frame_item in enumerate(
+            instance.PerFrameFunctionalGroupsSequence, 1
+        ):
+            frame_content_item = frame_item.FrameContentSequence[0]
+            # The slice location index values should be consecutive, starting
+            # at 1
+            assert frame_content_item.DimensionIndexValues[1] == i
         assert len(frame_content_item.DimensionIndexValues) == 2
         for derivation_image_item in frame_item.DerivationImageSequence:
             assert len(derivation_image_item.SourceImageSequence) == 1


### PR DESCRIPTION
This PR fixes a few known issues with the way highdicom deals with the dimension indices in the Segmentation Image IOD. The following changes are implemented:

- Dimension Organization UIDs are now created for every segmentation image, rather than the old, incorrect behaviour of using a fixed literal UID for every instance highdicom creates.
- A fix to the way dimension index values are calculated: previously this was wrong if there were empty frames in the segmentation pixel array
- In order to make the above fix, it was necessary to remove the `add_segments()` method of the `Segmentation` class because information about all segments is required when the instance is created in order to correctly calculate the dimension index value for every segment. To make this possible, the constructor can now accept a 4D array, where multiple segments (that would have previously been added sequentially via `add_segments`) may be concatenated along the fourth (final) dimension. This has a nice side effect of bringing the constructor in line with the "decoding" behaviour in #74, which returns 4D arrays with the same interpretation.
- An option to turn off the behaviour that omits empty frames from the segmentation image was added
- More unit tests to ensure that the dimension index values are correct