### PR TITLE
Added docstring for Segmentation's device_serial_number parameter

### DIFF
--- a/src/highdicom/seg/sop.py
+++ b/src/highdicom/seg/sop.py
@@ -137,6 +137,8 @@ class Segmentation(SOPClass):
             application) that creates the instance
         software_versions: Union[str, Tuple[str]]
             Version(s) of the software that creates the instance
+        device_serial_number: str
+            Manufacturer's serial number of the device
         fractional_type: Union[str, highdicom.seg.SegmentationFractionalTypeValues], optional
             Type of fractional segmentation that indicates how pixel data
             should be interpreted


### PR DESCRIPTION
The Segmentation class's `device_serial_number` is not documented, despite being a required parameter.

Added the missing docstring.