### PR TITLE
Alternative SCImage Constructor

### DIFF
--- a/src/highdicom/base.py
+++ b/src/highdicom/base.py
@@ -143,7 +143,7 @@ class SOPClass(Dataset):
         # Patient
         self.PatientID = patient_id
         self.PatientName = patient_name
-        self.PatientBirthDate = patient_birth_date
+        self.PatientBirthDate = DA(patient_birth_date)
         self.PatientSex = patient_sex
 
         # Study

--- a/src/highdicom/sc/sop.py
+++ b/src/highdicom/sc/sop.py
@@ -367,3 +367,158 @@ class SCImage(SOPClass):
             self.PixelData = encapsulate([encoded_frame])
         else:
             self.PixelData = encoded_frame
+
+    @classmethod
+    def from_study_dataset(
+        cls,
+        study_dataset: Dataset,
+        pixel_array: np.ndarray,
+        photometric_interpretation: Union[
+            str,
+            PhotometricInterpretationValues
+        ],
+        bits_allocated: int,
+        coordinate_system: Union[str, CoordinateSystemNames],
+        series_instance_uid: str,
+        series_number: int,
+        sop_instance_uid: str,
+        instance_number: int,
+        manufacturer: str,
+        pixel_spacing: Optional[Tuple[int, int]] = None,
+        laterality: Optional[Union[str, LateralityValues]] = None,
+        patient_orientation: Optional[
+            Union[
+                Tuple[str, str],
+                Tuple[
+                    PatientOrientationValuesBiped,
+                    PatientOrientationValuesBiped,
+                ],
+                Tuple[
+                    PatientOrientationValuesQuadruped,
+                    PatientOrientationValuesQuadruped,
+                ]
+            ]
+        ] = None,
+        anatomical_orientation_type: Optional[
+            Union[str, AnatomicalOrientationTypeValues]
+        ] = None,
+        container_identifier: Optional[str] = None,
+        issuer_of_container_identifier: Optional[IssuerOfIdentifier] = None,
+        specimen_descriptions: Optional[
+            Sequence[SpecimenDescription]
+        ] = None,
+        transfer_syntax_uid: str = ImplicitVRLittleEndian,
+        **kwargs: Any
+    ) -> 'SCImage':
+        """Constructor that copies patient and study from an existing dataset.
+
+        This provides a more concise way to construct an SCImage when an
+        existing dataset from the study is available. All patient- and study-
+        related attributes required by the main constructor are copied from the
+        ``study_dataset``, if present.
+
+        The ``study_dataset`` may be any dataset
+        from the study to which the resulting SC image should belong, and
+        contain all the relevant patient and study metadata. It does not need to
+        be specifically related to the contents of the SCImage.
+
+        Parameters
+        ----------
+        study_dataset: pydicom.dataset.Dataset
+            An existing dataset from the study to which the SCImage should
+            belong. Patient- and study-related metadata will be copied from
+            this dataset.
+        pixel_array: numpy.ndarray
+            Array of unsigned integer pixel values representing a single-frame
+            image; either a 2D grayscale image or a 3D color image
+            (RGB color space)
+        photometric_interpretation: Union[str, highdicom.enum.PhotometricInterpretationValues]
+            Interpretation of pixel data; either ``"MONOCHROME1"`` or
+            ``"MONOCHROME2"`` for 2D grayscale images or ``"RGB"`` or
+            ``"YBR_FULL"`` for 3D color images
+        bits_allocated: int
+            Number of bits that should be allocated per pixel value
+        coordinate_system: Union[str, highdicom.enum.CoordinateSystemNames]
+            Subject (``"PATIENT"`` or ``"SLIDE"``) that was the target of
+            imaging
+        series_instance_uid: str
+            Series Instance UID of the SC image series
+        series_number: Union[int, None]
+            Series Number of the SC image series
+        sop_instance_uid: str
+            SOP instance UID that should be assigned to the SC image instance
+        instance_number: int
+            Number that should be assigned to this SC image instance
+        manufacturer: str
+            Name of the manufacturer of the device that creates the SC image
+            instance (in a research setting this is typically the same
+            as `institution_name`)
+        pixel_spacing: Union[Tuple[int, int]], optional
+            Physical spacing in millimeter between pixels along the row and
+            column dimension
+        laterality: Union[str, highdicom.enum.LateralityValues, None], optional
+            Laterality of the examined body part
+        patient_orientation:
+                Union[Tuple[str, str], Tuple[highdicom.enum.PatientOrientationValuesBiped, highdicom.enum.PatientOrientationValuesBiped], Tuple[highdicom.enum.PatientOrientationValuesQuadruped, highdicom.enum.PatientOrientationValuesQuadruped], None], optional
+            Orientation of the patient along the row and column axes of the
+            image (required if `coordinate_system` is ``"PATIENT"``)
+        anatomical_orientation_type: Union[str, highdicom.enum.AnatomicalOrientationTypeValues, None], optional
+            Type of anatomical orientation of patient relative to image (may be
+            provide if `coordinate_system` is ``"PATIENT"`` and patient is
+            an animal)
+        container_identifier: Union[str], optional
+            Identifier of the container holding the specimen (required if
+            `coordinate_system` is ``"SLIDE"``)
+        issuer_of_container_identifier: Union[highdicom.IssuerOfIdentifier, None], optional
+            Issuer of `container_identifier`
+        specimen_descriptions: Union[Sequence[highdicom.SpecimenDescriptions], None], optional
+            Description of each examined specimen (required if
+            `coordinate_system` is ``"SLIDE"``)
+        transfer_syntax_uid: str, optional
+            UID of transfer syntax that should be used for encoding of
+            data elements. The following lossless compressed transfer syntaxes
+            are supported: RLE Lossless (``"1.2.840.10008.1.2.5"``).
+        **kwargs: Any, optional
+            Additional keyword arguments that will be passed to the constructor
+            of `highdicom.base.SOPClass`
+
+        Returns
+        -------
+        SCImage
+            Secondary capture image.
+
+        """  # noqa: E501
+        return cls(
+            pixel_array=pixel_array,
+            photometric_interpretation=photometric_interpretation,
+            bits_allocated=bits_allocated,
+            coordinate_system=coordinate_system,
+            study_instance_uid=study_dataset.StudyInstanceUID,
+            series_instance_uid=series_instance_uid,
+            series_number=series_number,
+            sop_instance_uid=sop_instance_uid,
+            instance_number=instance_number,
+            manufacturer=manufacturer,
+            patient_id=getattr(study_dataset, 'PatientID', None),
+            patient_name=getattr(study_dataset, 'PatientName', None),
+            patient_birth_date=getattr(study_dataset, 'PatientBirthDate', None),
+            patient_sex=getattr(study_dataset, 'PatientSex', None),
+            accession_number=getattr(study_dataset, 'AccessionNumber', None),
+            study_id=getattr(study_dataset, 'StudyID', None),
+            study_date=getattr(study_dataset, 'StudyDate', None),
+            study_time=getattr(study_dataset, 'StudyTime', None),
+            referring_physician_name=getattr(
+                study_dataset,
+                'ReferringPhysicianName',
+                None
+            ),
+            pixel_spacing=pixel_spacing,
+            laterality=laterality,
+            patient_orientation=patient_orientation,
+            anatomical_orientation_type=anatomical_orientation_type,
+            container_identifier=container_identifier,
+            issuer_of_container_identifier=issuer_of_container_identifier,
+            specimen_descriptions=specimen_descriptions,
+            transfer_syntax_uid=transfer_syntax_uid,
+            **kwargs
+        )

--- a/src/highdicom/sc/sop.py
+++ b/src/highdicom/sc/sop.py
@@ -369,9 +369,9 @@ class SCImage(SOPClass):
             self.PixelData = encoded_frame
 
     @classmethod
-    def from_study_dataset(
+    def from_ref_dataset(
         cls,
-        study_dataset: Dataset,
+        ref_dataset: Dataset,
         pixel_array: np.ndarray,
         photometric_interpretation: Union[
             str,
@@ -413,18 +413,18 @@ class SCImage(SOPClass):
         """Constructor that copies patient and study from an existing dataset.
 
         This provides a more concise way to construct an SCImage when an
-        existing dataset from the study is available. All patient- and study-
-        related attributes required by the main constructor are copied from the
-        ``study_dataset``, if present.
+        existing reference dataset from the study is available. All patient-
+        and study- related attributes required by the main constructor are
+        copied from the ``ref_dataset``, if present.
 
-        The ``study_dataset`` may be any dataset
+        The ``ref_dataset`` may be any dataset
         from the study to which the resulting SC image should belong, and
         contain all the relevant patient and study metadata. It does not need to
         be specifically related to the contents of the SCImage.
 
         Parameters
         ----------
-        study_dataset: pydicom.dataset.Dataset
+        ref_dataset: pydicom.dataset.Dataset
             An existing dataset from the study to which the SCImage should
             belong. Patient- and study-related metadata will be copied from
             this dataset.
@@ -493,22 +493,22 @@ class SCImage(SOPClass):
             photometric_interpretation=photometric_interpretation,
             bits_allocated=bits_allocated,
             coordinate_system=coordinate_system,
-            study_instance_uid=study_dataset.StudyInstanceUID,
+            study_instance_uid=ref_dataset.StudyInstanceUID,
             series_instance_uid=series_instance_uid,
             series_number=series_number,
             sop_instance_uid=sop_instance_uid,
             instance_number=instance_number,
             manufacturer=manufacturer,
-            patient_id=getattr(study_dataset, 'PatientID', None),
-            patient_name=getattr(study_dataset, 'PatientName', None),
-            patient_birth_date=getattr(study_dataset, 'PatientBirthDate', None),
-            patient_sex=getattr(study_dataset, 'PatientSex', None),
-            accession_number=getattr(study_dataset, 'AccessionNumber', None),
-            study_id=getattr(study_dataset, 'StudyID', None),
-            study_date=getattr(study_dataset, 'StudyDate', None),
-            study_time=getattr(study_dataset, 'StudyTime', None),
+            patient_id=getattr(ref_dataset, 'PatientID', None),
+            patient_name=getattr(ref_dataset, 'PatientName', None),
+            patient_birth_date=getattr(ref_dataset, 'PatientBirthDate', None),
+            patient_sex=getattr(ref_dataset, 'PatientSex', None),
+            accession_number=getattr(ref_dataset, 'AccessionNumber', None),
+            study_id=getattr(ref_dataset, 'StudyID', None),
+            study_date=getattr(ref_dataset, 'StudyDate', None),
+            study_time=getattr(ref_dataset, 'StudyTime', None),
             referring_physician_name=getattr(
-                study_dataset,
+                ref_dataset,
                 'ReferringPhysicianName',
                 None
             ),

--- a/src/highdicom/valuerep.py
+++ b/src/highdicom/valuerep.py
@@ -48,7 +48,7 @@ def check_person_name(person_name: Union[str, PersonName]) -> None:
         'http://dicom.nema.org/dicom/2013/output/chtml/part05/'
         'sect_6.2.html#sect_6.2.1.2'
     )
-    if '^' not in person_name:
+    if '^' not in person_name and person_name != '':  # empty string is allowed
         raise ValueError(
             f'The string "{person_name}" is unlikely to represent the '
             'intended person name since it contains only a single component. '

--- a/tests/test_sc.py
+++ b/tests/test_sc.py
@@ -31,7 +31,7 @@ class TestSCImage(unittest.TestCase):
         self._specimen_uid = generate_uid()
         file_path = Path(__file__)
         data_dir = file_path.parent.parent.joinpath('data')
-        self._study_dataset = dcmread(
+        self._ref_dataset = dcmread(
             str(data_dir.joinpath('test_files', 'ct_image.dcm'))
         )
 
@@ -289,12 +289,12 @@ class TestSCImage(unittest.TestCase):
             frame
         )
 
-    def test_construct_rgb_from_study_dataset(self):
+    def test_construct_rgb_from_ref_dataset(self):
         bits_allocated = 8
         photometric_interpretation = 'RGB'
         coordinate_system = 'PATIENT'
-        instance = SCImage.from_study_dataset(
-            study_dataset=self._study_dataset,
+        instance = SCImage.from_ref_dataset(
+            ref_dataset=self._ref_dataset,
             pixel_array=self._rgb_pixel_array,
             photometric_interpretation=photometric_interpretation,
             bits_allocated=bits_allocated,
@@ -311,7 +311,7 @@ class TestSCImage(unittest.TestCase):
         assert instance.SamplesPerPixel == 3
         assert instance.PlanarConfiguration == 0
         assert instance.PhotometricInterpretation == photometric_interpretation
-        assert instance.StudyInstanceUID == self._study_dataset.StudyInstanceUID
+        assert instance.StudyInstanceUID == self._ref_dataset.StudyInstanceUID
         assert instance.SeriesInstanceUID == self._series_instance_uid
         assert instance.SOPInstanceUID == self._sop_instance_uid
         assert instance.SeriesNumber == self._series_number
@@ -319,10 +319,10 @@ class TestSCImage(unittest.TestCase):
         assert instance.Manufacturer == self._manufacturer
         assert instance.Laterality == self._laterality
         assert instance.PatientOrientation == self._patient_orientation
-        assert instance.AccessionNumber == self._study_dataset.AccessionNumber
-        assert instance.PatientName == self._study_dataset.PatientName
-        assert instance.PatientSex == self._study_dataset.PatientSex
-        assert instance.StudyTime == TM(self._study_dataset.StudyTime)
-        assert instance.StudyDate == DA(self._study_dataset.StudyDate)
-        assert instance.StudyID == self._study_dataset.StudyID
+        assert instance.AccessionNumber == self._ref_dataset.AccessionNumber
+        assert instance.PatientName == self._ref_dataset.PatientName
+        assert instance.PatientSex == self._ref_dataset.PatientSex
+        assert instance.StudyTime == TM(self._ref_dataset.StudyTime)
+        assert instance.StudyDate == DA(self._ref_dataset.StudyDate)
+        assert instance.StudyID == self._ref_dataset.StudyID
         assert instance.PixelData == self._rgb_pixel_array.tobytes()

--- a/tests/test_sr.py
+++ b/tests/test_sr.py
@@ -2749,7 +2749,7 @@ class TestEnhancedSR(unittest.TestCase):
         self._ref_dataset = Dataset()
         self._ref_dataset.PatientID = '1'
         self._ref_dataset.PatientName = 'patient'
-        self._ref_dataset.PatientBirthDate = '2000101'
+        self._ref_dataset.PatientBirthDate = '20000101'
         self._ref_dataset.PatientSex = 'o'
         self._ref_dataset.SOPClassUID = '1.2.840.10008.5.1.4.1.1.2.2'
         self._ref_dataset.SOPInstanceUID = generate_uid()


### PR DESCRIPTION
The current constructor for the SCImage requires several pieces of patient or study related metadata. Often in practice, this information is simply copied from another dataset in the study in user code, but this process is annoying and verbose. I have now done this in several places personally.

This PR introduces a new alternative constructor for SCImage called `from_study_dataset` (open to other suggestions for the name), that accepts another dataset from the study and copies the patient and study related metadata from there. This should make user code more concise and less error prone for this very common situation. Also added tests.