### PR TITLE
Add properties to Measurement and QualitativeEvaluation

### DIFF
--- a/src/highdicom/sr/templates.py
+++ b/src/highdicom/sr/templates.py
@@ -2042,6 +2042,16 @@ class QualitativeEvaluation(Template):
         item = CodeContentItem.from_dataset(sequence[0])
         return cls(name=item.name, value=item.value)
 
+    @property
+    def name(self) -> CodedConcept:
+        """highdicom.sr.CodedConcept: name of the qualitative evaluation"""
+        return self[0].name
+
+    @property
+    def value(self) -> Union[int, float]:
+        """Union[int, float]: coded value of the qualitative evaluation"""
+        return self[0].value
+
 
 class Measurement(Template):
 
@@ -2232,6 +2242,26 @@ class Measurement(Template):
                 item.ContentSequence
             )
         return measurement
+
+    @property
+    def name(self) -> CodedConcept:
+        """highdicom.sr.CodedConcept: coded name of the measurement"""
+        return self[0].name
+
+    @property
+    def value(self) -> Union[int, float]:
+        """Union[int, float]: measured value"""
+        return self[0].value
+
+    @property
+    def unit(self) -> CodedConcept:
+        """highdicom.sr.coding.CodedConcept: unit"""
+        return self[0].unit
+
+    @property
+    def qualifier(self) -> Union[CodedConcept, None]:
+        """Union[highdicom.sr.coding.CodedConcept, None]: qualifier"""
+        return self[0].qualifier
 
 
 class MeasurementsAndQualitativeEvaluations(Template):

--- a/src/highdicom/sr/templates.py
+++ b/src/highdicom/sr/templates.py
@@ -2553,7 +2553,7 @@ class MeasurementsAndQualitativeEvaluations(Template):
     def get_measurements(
         self,
         name: Optional[Union[Code, CodedConcept]] = None
-    ) -> List[Union[Measurement]]:
+    ) -> List[Measurement]:
         """Get measurements.
 
         Parameters

--- a/tests/test_sr.py
+++ b/tests/test_sr.py
@@ -2139,6 +2139,12 @@ class TestMeasurement(unittest.TestCase):
         with pytest.raises(AttributeError):
             item.NumericValueQualifierCodeSequence
 
+        # Direct property access
+        assert measurement.name == self._name
+        assert measurement.value == self._value
+        assert measurement.unit == self._unit
+        assert measurement.qualifier is None
+
     def test_construction_with_missing_required_parameters(self):
         with pytest.raises(TypeError):
             Measurement(
@@ -2188,6 +2194,23 @@ class TestMeasurement(unittest.TestCase):
         assert subitem.ConceptCodeSequence[0] == self._location
         # Laterality and topological modifier were not specified
         assert not hasattr(subitem, 'ContentSequence')
+
+
+class TestQualitativeEvaluation(unittest.TestCase):
+
+    def setUp(self):
+        self._name = codes.DCM.LevelOfSignificance
+        self._value = codes.SCT.HighlySignificant
+
+    def test_construction(self):
+        evaluation = QualitativeEvaluation(
+            name=self._name,
+            value=self._value
+        )
+
+        assert len(evaluation) == 1
+        assert evaluation.name == self._name
+        assert evaluation.value == self._value
 
 
 class TestPlanarROIMeasurementsAndQualitativeEvaluations(unittest.TestCase):


### PR DESCRIPTION
Simple properties that allow you access name, value, unit, and qualifier (where applicable) of `Measurement` and `QualitativeEvaluation` classes. Since these classes are returned in the parsing API by the `get_measurements` and `get_qualitative_evaluations` methods, this makes them much more intuitive to work with.

```python
measurement = Measurement(...)

# Before
measurement[0].value
# Now
measurement.value
```