### PR TITLE
Content items of special templates lack relationship

### DIFF
--- a/src/highdicom/content.py
+++ b/src/highdicom/content.py
@@ -560,9 +560,9 @@ class SpecimenCollection(ContentSequence):
     """
 
     def __init__(
-            self,
-            procedure: Union[Code, CodedConcept]
-        ):
+        self,
+        procedure: Union[Code, CodedConcept]
+    ):
         """
         Parameters
         ----------
@@ -570,7 +570,7 @@ class SpecimenCollection(ContentSequence):
             Procedure used to collect the examined specimen
 
         """  # noqa: E501
-        super().__init__()
+        super().__init__(is_root=True)
         item = CodeContentItem(
             name=codes.SCT.SpecimenCollection,
             value=procedure
@@ -606,7 +606,7 @@ class SpecimenSampling(ContentSequence):
             Issuer who created the parent specimen
 
         """  # noqa: E501
-        super().__init__()
+        super().__init__(is_root=True)
         # CID 8110
         method_item = CodeContentItem(
             name=codes.DCM.SamplingMethod,
@@ -645,9 +645,9 @@ class SpecimenStaining(ContentSequence):
     """
 
     def __init__(
-            self,
-            substances: Sequence[Union[Code, CodedConcept]]
-        ):
+        self,
+        substances: Sequence[Union[Code, CodedConcept]]
+    ):
         """
         Parameters
         ----------
@@ -655,7 +655,7 @@ class SpecimenStaining(ContentSequence):
             Substances used to stain examined specimen(s)
 
         """  # noqa: E501
-        super().__init__()
+        super().__init__(is_root=True)
         # CID 8112
         for s in substances:
             item = CodeContentItem(
@@ -710,7 +710,7 @@ class SpecimenPreparationStep(ContentSequence):
             Embedding medium used during processing
 
         """  # noqa: E501
-        super().__init__()
+        super().__init__(is_root=True)
         specimen_identifier_item = TextContentItem(
             name=codes.DCM.SpecimenIdentifier,
             value=specimen_id

--- a/src/highdicom/sr/value_types.py
+++ b/src/highdicom/sr/value_types.py
@@ -642,19 +642,13 @@ class CodeContentItem(ContentItem):
         Parameters
         ----------
         name: Union[highdicom.sr.CodedConcept, pydicom.sr.coding.Code]
-            concept name
+            Concept name
         value: Union[highdicom.sr.CodedConcept, pydicom.sr.coding.Code]
-            coded value or an enumerated item representing a coded value
-        relationship_type: Union[highdicom.sr.RelationshipTypeValues, str]
-            type of relationship with parent content item
+            Coded value or an enumerated item representing a coded value
+        relationship_type: Union[highdicom.sr.RelationshipTypeValues, str, None], optional
+            Type of relationship with parent content item
 
         """  # noqa: E501
-        if relationship_type is None:
-            warnings.warn(
-                'A future release will require that relationship types be '
-                f'provided for items of type {self.__class__.__name__}.',
-                DeprecationWarning
-            )
         super(CodeContentItem, self).__init__(
             ValueTypeValues.CODE, name, relationship_type
         )
@@ -730,19 +724,13 @@ class PnameContentItem(ContentItem):
         Parameters
         ----------
         name: Union[highdicom.sr.CodedConcept, pydicom.sr.coding.Code]
-            concept name
+            Concept name
         value: Union[str, pydicom.valuerep.PersonName]
-            name of the person
-        relationship_type: Union[highdicom.sr.RelationshipTypeValues, str]
-            type of relationship with parent content item
+            Name of the person
+        relationship_type: Union[highdicom.sr.RelationshipTypeValues, str, None], optional
+            Type of relationship with parent content item
 
         """  # noqa: E501
-        if relationship_type is None:
-            warnings.warn(
-                'A future release will require that relationship types be '
-                f'provided for items of type {self.__class__.__name__}.',
-                DeprecationWarning
-            )
         super(PnameContentItem, self).__init__(
             ValueTypeValues.PNAME, name, relationship_type
         )
@@ -810,19 +798,13 @@ class TextContentItem(ContentItem):
         Parameters
         ----------
         name: Union[highdicom.sr.CodedConcept, pydicom.sr.coding.Code]
-            concept name
+            Concept name
         value: str
-            description of the concept in free text
-        relationship_type: Union[highdicom.sr.RelationshipTypeValues, str]
-            type of relationship with parent content item
+            Description of the concept in free text
+        relationship_type: Union[highdicom.sr.RelationshipTypeValues, str, None], optional
+            Type of relationship with parent content item
 
         """  # noqa: E501
-        if relationship_type is None:
-            warnings.warn(
-                'A future release will require that relationship types be '
-                f'provided for items of type {self.__class__.__name__}.',
-                DeprecationWarning
-            )
         super(TextContentItem, self).__init__(
             ValueTypeValues.TEXT, name, relationship_type
         )
@@ -889,19 +871,13 @@ class TimeContentItem(ContentItem):
         Parameters
         ----------
         name: Union[highdicom.sr.CodedConcept, pydicom.sr.coding.Code]
-            concept name
+            Concept name
         value: Union[str, datetime.time, pydicom.valuerep.TM]
-            time
-        relationship_type: Union[highdicom.sr.RelationshipTypeValues, str]
-            type of relationship with parent content item
+            Time
+        relationship_type: Union[highdicom.sr.RelationshipTypeValues, str, None], optional
+            Type of relationship with parent content item
 
         """  # noqa: E501
-        if relationship_type is None:
-            warnings.warn(
-                'A future release will require that relationship types be '
-                f'provided for items of type {self.__class__.__name__}.',
-                DeprecationWarning
-            )
         super(TimeContentItem, self).__init__(
             ValueTypeValues.TIME, name, relationship_type
         )
@@ -980,19 +956,13 @@ class DateContentItem(ContentItem):
         Parameters
         ----------
         name: Union[highdicom.sr.CodedConcept, pydicom.sr.coding.Code]
-            concept name
+            Concept name
         value: Union[str, datetime.date, pydicom.valuerep.DA]
-            date
-        relationship_type: Union[highdicom.sr.RelationshipTypeValues, str]
-            type of relationship with parent content item
+            Date
+        relationship_type: Union[highdicom.sr.RelationshipTypeValues, str, None], optional
+            Type of relationship with parent content item
 
         """  # noqa: E501
-        if relationship_type is None:
-            warnings.warn(
-                'A future release will require that relationship types be '
-                f'provided for items of type {self.__class__.__name__}.',
-                DeprecationWarning
-            )
         super(DateContentItem, self).__init__(
             ValueTypeValues.DATE, name, relationship_type
         )
@@ -1060,19 +1030,13 @@ class DateTimeContentItem(ContentItem):
         Parameters
         ----------
         name: Union[highdicom.sr.CodedConcept, pydicom.sr.coding.Code]
-            concept name
+            Concept name
         value: Union[str, datetime.datetime, pydicom.valuerep.DT]
-            datetime
-        relationship_type: Union[highdicom.sr.RelationshipTypeValues, str]
-            type of relationship with parent content item
+            Datetime
+        relationship_type: Union[highdicom.sr.RelationshipTypeValues, str, None], optional
+            Type of relationship with parent content item
 
         """  # noqa: E501
-        if relationship_type is None:
-            warnings.warn(
-                'A future release will require that relationship types be '
-                f'provided for items of type {self.__class__.__name__}.',
-                DeprecationWarning
-            )
         super(DateTimeContentItem, self).__init__(
             ValueTypeValues.DATETIME, name, relationship_type
         )
@@ -1158,19 +1122,13 @@ class UIDRefContentItem(ContentItem):
         Parameters
         ----------
         name: Union[highdicom.sr.CodedConcept, pydicom.sr.coding.Code]
-            concept name
+            Concept name
         value: Union[highdicom.UID, str]
-            unique identifier
-        relationship_type: Union[highdicom.sr.RelationshipTypeValues, str]
-            type of relationship with parent content item
+            Unique identifier
+        relationship_type: Union[highdicom.sr.RelationshipTypeValues, str, None], optional
+            Type of relationship with parent content item
 
         """  # noqa: E501
-        if relationship_type is None:
-            warnings.warn(
-                'A future release will require that relationship types be '
-                f'provided for items of type {self.__class__.__name__}.',
-                DeprecationWarning
-            )
         super(UIDRefContentItem, self).__init__(
             ValueTypeValues.UIDREF, name, relationship_type
         )
@@ -1239,27 +1197,21 @@ class NumContentItem(ContentItem):
         Parameters
         ----------
         name: Union[highdicom.sr.CodedConcept, pydicom.sr.coding.Code]
-            concept name
+            Concept name
         value: Union[int, float]
-            numeric value
+            Numeric value
         unit: Union[highdicom.sr.CodedConcept, pydicom.sr.coding.Code], optional
-            coded units of measurement (see :dcm:`CID 7181 <part16/sect_CID_7181.html>`
+            Coded units of measurement (see :dcm:`CID 7181 <part16/sect_CID_7181.html>`
             "Abstract Multi-dimensional Image Model Component Units")
         qualifier: Union[highdicom.sr.CodedConcept, pydicom.sr.coding.Code, None], optional
-            qualification of numeric value or as an alternative to
+            Qualification of numeric value or as an alternative to
             numeric value, e.g., reason for absence of numeric value
             (see :dcm:`CID 42 <part16/sect_CID_42.html>`
             "Numeric Value Qualifier" for options)
-        relationship_type: Union[highdicom.sr.RelationshipTypeValues, str]
-            type of relationship with parent content item
+        relationship_type: Union[highdicom.sr.RelationshipTypeValues, str, None], optional
+            Type of relationship with parent content item
 
         """  # noqa: E501
-        if relationship_type is None:
-            warnings.warn(
-                'A future release will require that relationship types be '
-                f'provided for items of type {self.__class__.__name__}.',
-                DeprecationWarning
-            )
         super(NumContentItem, self).__init__(
             ValueTypeValues.NUM, name, relationship_type
         )
@@ -1475,21 +1427,15 @@ class CompositeContentItem(ContentItem):
         Parameters
         ----------
         name: Union[highdicom.sr.CodedConcept, pydicom.sr.coding.Code]
-            concept name
+            Concept name
         referenced_sop_class_uid: Union[highdicom.UID, str]
             SOP Class UID of the referenced object
         referenced_sop_instance_uid: Union[highdicom.UID, str]
             SOP Instance UID of the referenced object
-        relationship_type: Union[highdicom.sr.RelationshipTypeValues, str]
-            type of relationship with parent content item
+        relationship_type: Union[highdicom.sr.RelationshipTypeValues, str, None], optional
+            Type of relationship with parent content item
 
         """  # noqa: E501
-        if relationship_type is None:
-            warnings.warn(
-                'A future release will require that relationship types be '
-                f'provided for items of type {self.__class__.__name__}.',
-                DeprecationWarning
-            )
         super(CompositeContentItem, self).__init__(
             ValueTypeValues.COMPOSITE, name, relationship_type
         )
@@ -1572,27 +1518,21 @@ class ImageContentItem(ContentItem):
         Parameters
         ----------
         name: Union[highdicom.sr.CodedConcept, pydicom.sr.coding.Code]
-            concept name
+            Concept name
         referenced_sop_class_uid: Union[highdicom.UID, str]
             SOP Class UID of the referenced image object
         referenced_sop_instance_uid: Union[highdicom.UID, str]
             SOP Instance UID of the referenced image object
         referenced_frame_numbers: Union[int, Sequence[int], None], optional
-            number of frame(s) to which the reference applies in case of a
+            Number of frame(s) to which the reference applies in case of a
             multi-frame image
         referenced_segment_numbers: Union[int, Sequence[int], None], optional
-            number of segment(s) to which the refernce applies in case of a
+            Number of segment(s) to which the refernce applies in case of a
             segmentation image
-        relationship_type: Union[highdicom.sr.RelationshipTypeValues, str]
-            type of relationship with parent content item
+        relationship_type: Union[highdicom.sr.RelationshipTypeValues, str, None], optional
+            Type of relationship with parent content item
 
         """  # noqa: E501
-        if relationship_type is None:
-            warnings.warn(
-                'A future release will require that relationship types be '
-                f'provided for items of type {self.__class__.__name__}.',
-                DeprecationWarning
-            )
         super(ImageContentItem, self).__init__(
             ValueTypeValues.IMAGE, name, relationship_type
         )
@@ -1684,30 +1624,24 @@ class ScoordContentItem(ContentItem):
         Parameters
         ----------
         name: Union[highdicom.sr.CodedConcept, pydicom.sr.coding.Code]
-            concept name
+            Concept name
         graphic_type: Union[highdicom.sr.GraphicTypeValues, str]
-            name of the graphic type
+            Name of the graphic type
         graphic_data: numpy.ndarray[numpy.int]
-            array of ordered spatial coordinates, where each row of the array
+            Array of ordered spatial coordinates, where each row of the array
             represents a (column, row) coordinate pair
         pixel_origin_interpretation: Union[highdicom.sr.PixelOriginInterpretationValues, str, None], optional
-            whether pixel coordinates specified by `graphic_data` are defined
+            Whether pixel coordinates specified by `graphic_data` are defined
             relative to the total pixel matrix
             (``highdicom.sr.PixelOriginInterpretationValues.VOLUME``) or
             relative to an individual frame
             (``highdicom.sr.PixelOriginInterpretationValues.FRAME``)
         fiducial_uid: Union[highdicom.UID, str, None], optional
-            unique identifier for the content item
-        relationship_type: Union[highdicom.sr.RelationshipTypeValues, str]
-            type of relationship with parent content item
+            Unique identifier for the content item
+        relationship_type: Union[highdicom.sr.RelationshipTypeValues, str, None], optional
+            Type of relationship with parent content item
 
         """  # noqa: E501
-        if relationship_type is None:
-            warnings.warn(
-                'A future release will require that relationship types be '
-                f'provided for items of type {self.__class__.__name__}.',
-                DeprecationWarning
-            )
         super(ScoordContentItem, self).__init__(
             ValueTypeValues.SCOORD, name, relationship_type
         )
@@ -1828,27 +1762,21 @@ class Scoord3DContentItem(ContentItem):
         Parameters
         ----------
         name: Union[highdicom.sr.CodedConcept, pydicom.sr.coding.Code]
-            concept name
+            Concept name
         graphic_type: Union[highdicom.sr.GraphicTypeValues3D, str]
-            name of the graphic type
+            Name of the graphic type
         graphic_data: numpy.ndarray[numpy.float]
-            array of spatial coordinates, where each row of the array
+            Array of spatial coordinates, where each row of the array
             represents a (x, y, z) coordinate triplet
         frame_of_reference_uid: Union[highdicom.UID, str]
-            unique identifier of the frame of reference within which the
+            Unique identifier of the frame of reference within which the
             coordinates are defined
         fiducial_uid: Union[str, None], optional
-            unique identifier for the content item
-        relationship_type: Union[highdicom.sr.RelationshipTypeValues, str]
-            type of relationship with parent content item
+            Unique identifier for the content item
+        relationship_type: Union[highdicom.sr.RelationshipTypeValues, str, None], optional
+            Type of relationship with parent content item
 
         """  # noqa: E501
-        if relationship_type is None:
-            warnings.warn(
-                'A future release will require that relationship types be '
-                f'provided for items of type {self.__class__.__name__}.',
-                DeprecationWarning
-            )
         super(Scoord3DContentItem, self).__init__(
             ValueTypeValues.SCOORD3D, name, relationship_type
         )
@@ -1958,26 +1886,20 @@ class TcoordContentItem(ContentItem):
         Parameters
         ----------
         name: Union[highdicom.sr.CodedConcept, pydicom.sr.coding.Code]
-            concept name
+            Concept name
         temporal_range_type: Union[highdicom.sr.TemporalRangeTypeValues, str]
-            name of the temporal range type
+            Name of the temporal range type
         referenced_sample_positions: Union[Sequence[int], None], optional
-            one-based relative sample position of acquired time points
+            One-based relative sample position of acquired time points
             within the time series
         referenced_time_offsets: Union[Sequence[float], None], optional
-            seconds after start of the acquisition of the time series
+            Seconds after start of the acquisition of the time series
         referenced_date_time: Union[Sequence[datetime.datetime], None], optional
-            absolute time points
-        relationship_type: Union[highdicom.sr.RelationshipTypeValues, str]
-            type of relationship with parent content item
+            Absolute time points
+        relationship_type: Union[highdicom.sr.RelationshipTypeValues, str, None], optional
+            Type of relationship with parent content item
 
         """  # noqa: E501
-        if relationship_type is None:
-            warnings.warn(
-                'A future release will require that relationship types be '
-                f'provided for items of type {self.__class__.__name__}.',
-                DeprecationWarning
-            )
         super(TcoordContentItem, self).__init__(
             ValueTypeValues.TCOORD, name, relationship_type
         )

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -1,11 +1,15 @@
 from unittest import TestCase
 
 import pytest
+from pydicom.sr.codedict import codes
 
 from highdicom import (
     PixelMeasuresSequence,
     PlaneOrientationSequence,
     PlanePositionSequence,
+    SpecimenCollection,
+    SpecimenSampling,
+    SpecimenStaining,
 )
 
 
@@ -106,3 +110,63 @@ class TestPixelMeasuresSequence(TestCase):
         assert len(seq) == 1
         item = seq[0]
         assert item.SpacingBetweenSlices == spacing_between_slices
+
+
+class TestSpecimenCollection(TestCase):
+
+    def test_construction(self):
+        procedure = codes.SCT.Biopsy
+        seq = SpecimenCollection(procedure=procedure)
+        assert len(seq) == 1
+        assert seq.is_root
+        item = seq[0]
+        assert item.name == codes.SCT.SpecimenCollection
+        assert item.value == procedure
+        assert item.relationship_type is None
+
+
+class TestSpecimenSampling(TestCase):
+
+    def test_construction(self):
+        method = codes.SCT.BlockSectioning
+        parent_id = '1'
+        parent_type = codes.SCT.GrossSpecimen
+        seq = SpecimenSampling(
+            method=method,
+            parent_specimen_id=parent_id,
+            parent_specimen_type=parent_type
+        )
+        assert len(seq) == 3
+        assert seq.is_root
+        method_item = seq[0]
+        assert method_item.name == codes.DCM.SamplingMethod
+        assert method_item.value == method
+        assert method_item.relationship_type is None
+        parent_id_item = seq[1]
+        assert parent_id_item.name == codes.DCM.ParentSpecimenIdentifier
+        assert parent_id_item.value == parent_id
+        assert parent_id_item.relationship_type is None
+        parent_type_item = seq[2]
+        assert parent_type_item.name == codes.DCM.ParentSpecimenType
+        assert parent_type_item.value == parent_type
+        assert parent_type_item.relationship_type is None
+
+
+class TestSpecimenStaining(TestCase):
+
+    def test_construction(self):
+        substances = [
+            codes.SCT.HematoxylinStain,
+            codes.SCT.WaterSolubleEosinStain
+        ]
+        seq = SpecimenStaining(substances=substances)
+        assert len(seq) == 2
+        assert seq.is_root
+        hematoxylin_item = seq[0]
+        assert hematoxylin_item.name == codes.SCT.UsingSubstance
+        assert hematoxylin_item.value == substances[0]
+        assert hematoxylin_item.relationship_type is None
+        eosin_item = seq[1]
+        assert eosin_item.name == codes.SCT.UsingSubstance
+        assert eosin_item.value == substances[1]
+        assert eosin_item.relationship_type is None


### PR DESCRIPTION
Content items of acquisition and protocol templates don't have a Relationship field. We consider these items to be similar to CONTAINER items at the root of a SR document content tree and instantiate `ContentSequence` objects with `is_root` to allow content items without the `RelationshipType` attribute.