### PR TITLE
Fix code name for embedding medium

### DIFF
--- a/src/highdicom/content.py
+++ b/src/highdicom/content.py
@@ -772,7 +772,7 @@ class SpecimenPreparationStep(ContentSequence):
             self.append(tissue_fixative_item)
         if embedding_medium is not None:
             embedding_medium_item = CodeContentItem(
-                name=codes.SCT.EmbeddingMedium,
+                name=codes.SCT.TissueEmbeddingMedium,
                 value=embedding_medium
             )
             self.append(embedding_medium_item)

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -170,3 +170,105 @@ class TestSpecimenStaining(TestCase):
         assert eosin_item.name == codes.SCT.UsingSubstance
         assert eosin_item.value == substances[1]
         assert eosin_item.relationship_type is None
+
+        
+class TestSpecimenPreparationStep(TestCase):
+
+    def test_construction_collection(self):
+        specimen_id = 'specimen id'
+        processing_type = codes.SCT.SpecimenCollection
+        procedure = codes.SCT.Excision
+        seq = SpecimenPreparationStep(
+            specimen_id=specimen_id,
+            processing_type=processing_type,
+            processing_procedure=SpecimenCollection(procedure=procedure)
+        )
+        assert len(seq) == 3
+        assert seq.is_root
+        specimen_id_item = seq[0]
+        assert specimen_id_item.name == codes.DCM.SpecimenIdentifier
+        assert specimen_id_item.value == specimen_id
+        assert specimen_id_item.relationship_type is None
+        processing_type_item = seq[1]
+        assert processing_type_item.name == codes.DCM.ProcessingType
+        assert processing_type_item.value == processing_type
+        assert processing_type_item.relationship_type is None
+        procedure_item = seq[2]
+        assert procedure_item.name == codes.SCT.SpecimenCollection
+        assert procedure_item.value == procedure
+        assert procedure_item.relationship_type is None
+
+    def test_construction_sampling(self):
+        specimen_id = 'specimen id'
+        processing_type = codes.SCT.SamplingOfTissueSpecimen
+        method = codes.DCM.DissectionWithRepresentativeSectionsSubmission
+        parent_specimen_id = 'parent specimen id'
+        parent_specimen_type = codes.SCT.TissueSpecimen
+        fixative = codes.SCT.Formalin
+        embedding_medium = codes.SCT.ParaffinWax
+        seq = SpecimenPreparationStep(
+            specimen_id=specimen_id,
+            processing_type=processing_type,
+            processing_procedure=SpecimenSampling(
+                method=method,
+                parent_specimen_id=parent_specimen_id,
+                parent_specimen_type=parent_specimen_type
+            ),
+            fixative=fixative,
+            embedding_medium=embedding_medium
+        )
+        assert len(seq) == 7
+        assert seq.is_root
+        specimen_id_item = seq[0]
+        assert specimen_id_item.name == codes.DCM.SpecimenIdentifier
+        assert specimen_id_item.value == specimen_id
+        assert specimen_id_item.relationship_type is None
+        processing_type_item = seq[1]
+        assert processing_type_item.name == codes.DCM.ProcessingType
+        assert processing_type_item.value == processing_type
+        assert processing_type_item.relationship_type is None
+        method_item = seq[2]
+        assert method_item.name == codes.DCM.SamplingMethod
+        assert method_item.value == method
+        assert method_item.relationship_type is None
+        parent_specimen_id_item = seq[3]
+        assert parent_specimen_id_item.name == codes.DCM.ParentSpecimenIdentifier
+        assert parent_specimen_id_item.value == parent_specimen_id
+        assert parent_specimen_id_item.relationship_type is None
+        parent_specimen_type_item = seq[4]
+        assert parent_specimen_type_item.name == codes.DCM.ParentSpecimenType
+        assert parent_specimen_type_item.value == parent_specimen_type
+        assert parent_specimen_type_item.relationship_type is None
+        fixative_item = seq[5]
+        assert fixative_item.name == codes.SCT.TissueFixative
+        assert fixative_item.value == fixative
+        assert fixative_item.relationship_type is None
+        embedding_medium_item = seq[6]
+        assert embedding_medium_item.name == codes.SCT.TissueEmbeddingMedium
+        assert embedding_medium_item.value == embedding_medium
+        assert embedding_medium_item.relationship_type is None
+
+    def test_construction_staining(self):
+        specimen_id = 'specimen id'
+        processing_type = codes.SCT.Staining
+        substance = codes.SCT.HematoxylinStain
+        seq = SpecimenPreparationStep(
+            specimen_id=specimen_id,
+            processing_type=processing_type,
+            processing_procedure=SpecimenStaining(substances=[substance])
+        )
+        assert len(seq) == 3
+        assert seq.is_root
+        specimen_id_item = seq[0]
+        assert specimen_id_item.name == codes.DCM.SpecimenIdentifier
+        assert specimen_id_item.value == specimen_id
+        assert specimen_id_item.relationship_type is None
+        processing_type_item = seq[1]
+        assert processing_type_item.name == codes.DCM.ProcessingType
+        assert processing_type_item.value == processing_type
+        assert processing_type_item.relationship_type is None
+        staining_item = seq[2]
+        assert staining_item.name == codes.SCT.UsingSubstance
+        assert staining_item.value == substance
+        assert staining_item.relationship_type is None
+


### PR DESCRIPTION
With:
```python
preparation_step = SpecimenPreparationStep(
    specimen_id = 'specimen id',
    processing_type = Code('P3-4000A', 'SRT', 'Sampling of tissue specimen'),
    processing_procedure = SpecimenSampling(
        method = Code('111727', 'SRT', 'Dissection with representative sections submission'),
        parent_specimen_id = 'parent specimen id',
        parent_specimen_type = Code('G-8300', 'SRT', 'Tissue specimen')
    ),
    embedding_medium = Code('F-616D8', 'SRT', 'Paraffin wax'),
)
```
I get:
```python
AttributeError: Unknown code name 'EmbeddingMedium' for scheme 'SCT'
```

The problem is that codes.SCT.EmbeddingMedium in SpecimenPreparationStep should be codes.SCT.TissueEmbeddingMedium.