### PR TITLE
Correct comment in secondary capture usage example

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -378,7 +378,7 @@ labelled bounding box region drawn over a CT image.
     image_dataset = dcmread('/path/to/image.dcm')
 
     # Create an image for display by windowing the original image and drawing a
-    # bounding box over it using OpenCV
+    # bounding box over it using Pillow's ImageDraw module
     slope = getattr(image_dataset, 'RescaleSlope', 1)
     intercept = getattr(image_dataset, 'RescaleIntercept', 0)
     original_image = image_dataset.pixel_array * slope + intercept


### PR DESCRIPTION
Small typo in the comment of the Secondary Capture example I recently pushed. Comment said using OpenCV (which was correct in an earlier version) but code actually uses Pillow