### PR TITLE
Make ImageRegion3Ds invalid for volumetric measurements group

### DIFF
--- a/src/highdicom/sr/templates.py
+++ b/src/highdicom/sr/templates.py
@@ -2967,7 +2967,7 @@ class VolumetricROIMeasurementsAndQualitativeEvaluations(
         self,
         tracking_identifier: TrackingIdentifier,
         referenced_regions: Optional[
-            Union[Sequence[ImageRegion], Sequence[ImageRegion3D]]
+            Union[Sequence[ImageRegion]]
         ] = None,
         referenced_volume_surface: Optional[VolumeSurface] = None,
         referenced_segment: Optional[
@@ -2992,7 +2992,7 @@ class VolumetricROIMeasurementsAndQualitativeEvaluations(
         ----------
         tracking_identifier: highdicom.sr.TrackingIdentifier
             identifier for tracking measurements
-        referenced_regions: Union[Sequence[highdicom.sr.ImageRegion], Sequence[highdicom.sr.ImageRegion3D], None], optional
+        referenced_regions: Union[Sequence[highdicom.sr.ImageRegion], None], optional
             regions of interest in source image(s)
         referenced_volume_surface: Union[highdicom.sr.VolumeSurface, None], optional
             volume of interest in source image(s)
@@ -3031,6 +3031,16 @@ class VolumetricROIMeasurementsAndQualitativeEvaluations(
         together with the corresponding source image(s) or series.
 
         """  # noqa: E501
+        if referenced_regions is not None and any(
+            isinstance(r, ImageRegion3D) for r in referenced_regions
+        ):
+            raise TypeError(
+                'Including items of type ImageRegion3D in "referenced_regions" '
+                'is invalid within a volumetric ROI measurement group is '
+                'invalid. To specify the referenced region in 3D frame of '
+                'reference coordinates, use the "referenced_volume_surface" '
+                'argument instead.'
+            )
         super().__init__(
             measurements=measurements,
             tracking_identifier=tracking_identifier,


### PR DESCRIPTION
As was looking through the definition of [TID 1411](http://dicom.nema.org/medical/dicom/current/output/chtml/part16/chapter_A.html#sect_TID_1411) "Volumetric ROI Measurements and Qualitative Evaluations" I noticed that in fact it is not part of the template to allow Image Region items to use SCOORD3D. In TID 1410 (Planar...), this is allowed. However in TID 1411 the only way to specify points in the 3D frame of reference is via "Volume Surface" items and not "Image Region" items.

Unfortunately, highdicom currently allows the user to pass a sequence of `ImageRegion3D` objects (which have value type SCOORD3D) items to the constructor of `VolumetricROIMeasurementsAndQualitative Evaluations`, which would give rise to an invalid instantiation of the template. This PR removes this option in the type signatures and docstrings, and enforces it via runtime checks.

However there is a further, uglier issue: the template actually uses "Volume Surface" items with multiplicity 1-n. This is the only way to include multiple planes of interest using SCOORD3D (since Image Regions using SCOORD3D are not allowed). However, only a single `VolumeSurface` is supported by the constructor. I have not yet attempted to fix this part of the issue. We could change the `referenced_volume_surface` from `Optional[VolumeSurface]` to `Optional[Sequence[VolumeSurface]]` but this would be backwards incompatible. Do you think we should allow both, i.e. (`Optional[Union[VolumeSurface, Sequence[VolumeSurface]]]`) for a few releases? @hackermd 