### PR TITLE
Annotation init files

### DIFF
--- a/src/highdicom/__init__.py
+++ b/src/highdicom/__init__.py
@@ -3,6 +3,7 @@ from highdicom import pm
 from highdicom import sc
 from highdicom import seg
 from highdicom import sr
+from highdicom import ann
 from highdicom import color
 from highdicom.content import (
     AlgorithmIdentificationSequence,
@@ -60,6 +61,7 @@ __all__ = [
     'SpecimenStaining',
     'UID',
     'UniversalEntityIDTypeValues',
+    'ann',
     'color',
     'frame',
     'io',

--- a/src/highdicom/ann/__init__.py
+++ b/src/highdicom/ann/__init__.py
@@ -1,4 +1,11 @@
 """Package for creation of Annotation (ANN) instances."""
+from highdicom.ann.content import Measurements, AnnotationGroup
+from highdicom.ann.enum import (
+    AnnotationCoordinateTypeValues,
+    AnnotationGroupGenerationTypeValues,
+    GraphicTypeValues,
+    PixelOriginInterpretationValues,
+)
 from highdicom.ann.sop import MicroscopyBulkSimpleAnnotations
 
 SOP_CLASS_UIDS = {
@@ -6,5 +13,11 @@ SOP_CLASS_UIDS = {
 }
 
 __all__ = [
+    'AnnotationCoordinateTypeValues',
+    'AnnotationGroup',
+    'AnnotationGroupGenerationTypeValues',
+    'GraphicTypeValues',
+    'Measurements',
     'MicroscopyBulkSimpleAnnotations',
+    'PixelOriginInterpretationValues',
 ]


### PR DESCRIPTION
It seems like the `__init__` files were not correctly populated so things aren't importing properly for me if I use the "recommended" pattern...

We should probably switch to using the "recommended" import pattern, e.g.

```python
import highdicom as hd

hd.ann.AnnotationGroup(...)
```

consistently throughout the tests to avoid things like this slipping through.

Have fixed the inits for you and target this pull request at the feature branch