### PR TITLE
Fix `from_dataset` constructor in `KeyObjectSelectionDocument`

### DIFF
--- a/src/highdicom/ko/content.py
+++ b/src/highdicom/ko/content.py
@@ -172,7 +172,7 @@ class KeyObjectSelection(ContentSequence):
                 'Item #1 of sequence is not an appropriate SR Content Item '
                 'because it does not have Template Identifier "2010".'
             )
-        instance = ContentSequence.from_sequence(sequence, is_root=True)
+        instance = ContentSequence.from_sequence(sequence, is_root=is_root)
         instance.__class__ = KeyObjectSelection
         return cast(KeyObjectSelection, instance)
 

--- a/src/highdicom/ko/content.py
+++ b/src/highdicom/ko/content.py
@@ -172,7 +172,7 @@ class KeyObjectSelection(ContentSequence):
                 'Item #1 of sequence is not an appropriate SR Content Item '
                 'because it does not have Template Identifier "2010".'
             )
-        instance = ContentSequence.from_sequence(sequence, is_root=is_root)
+        instance = ContentSequence.from_sequence(sequence, is_root=True)
         instance.__class__ = KeyObjectSelection
         return cast(KeyObjectSelection, instance)
 

--- a/src/highdicom/ko/sop.py
+++ b/src/highdicom/ko/sop.py
@@ -207,6 +207,7 @@ class KeyObjectSelectionDocument(SOPClass):
         root_item = Dataset()
         root_item.ConceptNameCodeSequence = dataset.ConceptNameCodeSequence
         root_item.ContentSequence = dataset.ContentSequence
+        root_item.ContentTemplateSequence = dataset.ContentTemplateSequence
         root_item.ValueType = dataset.ValueType
         root_item.ContinuityOfContent = dataset.ContinuityOfContent
         content_item = ContainerContentItem.from_dataset(root_item)

--- a/src/highdicom/ko/sop.py
+++ b/src/highdicom/ko/sop.py
@@ -1,6 +1,7 @@
 """Module for SOP Classes of Key Object (KO) IODs."""
 import logging
 from typing import Any, cast, List, Optional, Sequence, Tuple, Union
+from copy import deepcopy
 
 from pydicom.dataset import Dataset
 from pydicom.uid import (
@@ -182,7 +183,8 @@ class KeyObjectSelectionDocument(SOPClass):
                 f'"{sop_instance_uid}" in KOS document.'
             )
 
-    def from_dataset(self, dataset: Dataset) -> 'KeyObjectSelectionDocument':
+    @classmethod
+    def from_dataset(cls, dataset: Dataset) -> 'KeyObjectSelectionDocument':
         """Construct object from an existing dataset.
 
         Parameters
@@ -198,8 +200,8 @@ class KeyObjectSelectionDocument(SOPClass):
         """
         if dataset.SOPClassUID != KeyObjectSelectionDocumentStorage:
             raise ValueError('Dataset is not a Key Object Selection Document.')
-        sop_instance = super().from_dataset(dataset)
-        sop_instance.__class__ = KeyObjectSelectionDocument
+        sop_instance = deepcopy(dataset)
+        sop_instance.__class__ = cls
 
         # Cache copy of the content to facilitate subsequent access
         root_item = Dataset()
@@ -214,7 +216,7 @@ class KeyObjectSelectionDocument(SOPClass):
         )
 
         sop_instance._reference_lut = {}
-        for study_item in self.CurrentRequestedProcedureEvidenceSequence:
+        for study_item in sop_instance.CurrentRequestedProcedureEvidenceSequence:  # noqa: E501
             for series_item in study_item.ReferencedSeriesSequence:
                 for instance_item in series_item.ReferencedSOPSequence:
                     sop_instance_uid = instance_item.ReferencedSOPInstanceUID

--- a/tests/test_ko.py
+++ b/tests/test_ko.py
@@ -201,3 +201,37 @@ class TestKeyObjectSelectionDocument(unittest.TestCase):
         assert study_uid == self._sm_image.StudyInstanceUID
         assert series_uid == self._sm_image.SeriesInstanceUID
         assert instance_uid == self._sm_image.SOPInstanceUID
+
+    def test_construction_from_dataset(self):
+        document = KeyObjectSelectionDocument(
+            evidence=self._evidence,
+            content=self._content,
+            series_instance_uid=UID(),
+            series_number=10,
+            sop_instance_uid=UID(),
+            instance_number=1,
+            manufacturer='MGH Computational Pathology',
+            institution_name='Massachusetts General Hospital',
+            institutional_department_name='Pathology'
+        )
+        assert isinstance(document, KeyObjectSelectionDocument)
+        assert isinstance(document.content, KeyObjectSelection)
+
+        test_document = KeyObjectSelectionDocument.from_dataset(document)
+        assert isinstance(test_document, KeyObjectSelectionDocument)
+        assert isinstance(test_document.content, KeyObjectSelection)
+        assert test_document.Modality == 'KO'
+        assert hasattr(
+            test_document, 'CurrentRequestedProcedureEvidenceSequence'
+        )
+        assert len(test_document.CurrentRequestedProcedureEvidenceSequence) > 0
+        assert hasattr(
+            test_document, 'ReferencedPerformedProcedureStepSequence'
+        )
+
+        study_uid, series_uid, instance_uid = test_document.resolve_reference(
+            self._sm_image.SOPInstanceUID
+        )
+        assert study_uid == self._sm_image.StudyInstanceUID
+        assert series_uid == self._sm_image.SeriesInstanceUID
+        assert instance_uid == self._sm_image.SOPInstanceUID

--- a/tests/test_ko.py
+++ b/tests/test_ko.py
@@ -1,3 +1,4 @@
+from io import BytesIO
 import unittest
 from pathlib import Path
 
@@ -217,7 +218,12 @@ class TestKeyObjectSelectionDocument(unittest.TestCase):
         assert isinstance(document, KeyObjectSelectionDocument)
         assert isinstance(document.content, KeyObjectSelection)
 
-        test_document = KeyObjectSelectionDocument.from_dataset(document)
+        with BytesIO() as fp:
+            document.save_as(fp)
+            fp.seek(0)
+            document_reread = dcmread(fp)
+
+        test_document = KeyObjectSelectionDocument.from_dataset(document_reread)
         assert isinstance(test_document, KeyObjectSelectionDocument)
         assert isinstance(test_document.content, KeyObjectSelection)
         assert test_document.Modality == 'KO'


### PR DESCRIPTION
Fixed the class method `KeyObjectSelection.from_dataset()` and added a test for it.

I had to change a bit around so you may want to pay close attention to what I did to ensure it makes sense.