### PR TITLE
Add support for JPEG-LS encoding/decoding

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,10 @@ setuptools.setup(
     install_requires=[
         'pydicom>=2.2.2',
         'numpy>=1.19',
-        'pillow>=8.3'
+        'pillow>=8.3',
+        'pillow-jpls>=1.0',
+        'pylibjpeg>=1.3',
+        'pylibjpeg-libjpeg>=1.2',
+        'pylibjpeg-openjpeg>=1.1',
     ],
 )

--- a/src/highdicom/legacy/sop.py
+++ b/src/highdicom/legacy/sop.py
@@ -6,8 +6,16 @@ from typing import Any, Dict, List, Optional, Sequence
 
 from pydicom.datadict import tag_for_keyword
 from pydicom.dataset import Dataset
+from pydicom.encaps import encapsulate
+from pydicom.uid import (
+    ImplicitVRLittleEndian,
+    ExplicitVRLittleEndian,
+    JPEG2000Lossless,
+    JPEGLSLossless,
+)
 
 from highdicom.base import SOPClass
+from highdicom.frame import encode_frame
 from highdicom._iods import IOD_MODULE_MAP, SOP_CLASS_UID_IOD_KEY_MAP
 from highdicom._modules import MODULE_ATTRIBUTE_MAP
 
@@ -26,9 +34,9 @@ LEGACY_ENHANCED_SOP_CLASS_UID_MAP = {
 
 
 def _convert_legacy_to_enhanced(
-        sf_datasets: Sequence[Dataset],
-        mf_dataset: Optional[Dataset] = None
-    ) -> Dataset:
+    sf_datasets: Sequence[Dataset],
+    mf_dataset: Optional[Dataset] = None
+) -> Dataset:
     """Converts one or more MR, CT or PET Image instances into one
     Legacy Converted Enhanced MR/CT/PET Image instance by copying information
     from `sf_datasets` into `mf_dataset`.
@@ -383,15 +391,25 @@ def _convert_legacy_to_enhanced(
 
     mf_dataset.AcquisitionContextSequence = []
 
-    # TODO: Encapsulated Pixel Data with compressed frame items.
-
     # Create the Pixel Data element of the mulit-frame image instance using
     # native encoding (simply concatenating pixels of individual frames)
     # Sometimes there may be numpy types such as ">i2". The (* 1) hack
     # ensures that pixel values have the correct integer type.
-    mf_dataset.PixelData = b''.join([
-        (ds.pixel_array * 1).data for ds in sf_datasets
-    ])
+    encoded_frames = [
+        encode_frame(
+            ds.pixel_array * 1,
+            transfer_syntax_uid=mf_dataset.file_meta.TransferSyntaxUID,
+            bits_allocated=ds.BitsAllocated,
+            bits_stored=ds.BitsStored,
+            photometric_interpretation=ds.PhotometricInterpretation,
+            pixel_representation=ds.PixelRepresentation
+        )
+        for ds in sf_datasets
+    ]
+    if mf_dataset.file_meta.TransferSyntaxUID.is_encapsulated:
+        mf_dataset.PixelData = encapsulate(encoded_frames)
+    else:
+        mf_dataset.PixelData = b''.join(encoded_frames)
 
     return mf_dataset
 
@@ -407,6 +425,7 @@ class LegacyConvertedEnhancedMRImage(SOPClass):
         series_number: int,
         sop_instance_uid: str,
         instance_number: int,
+        transfer_syntax_uid: str = ExplicitVRLittleEndian,
         **kwargs: Any
     ) -> None:
         """
@@ -423,6 +442,11 @@ class LegacyConvertedEnhancedMRImage(SOPClass):
             UID that should be assigned to the instance
         instance_number: int
             Number that should be assigned to the instance
+        transfer_syntax_uid: str, optional
+            UID of transfer syntax that should be used for encoding of
+            data elements. The following compressed transfer syntaxes
+            are supported: JPEG 2000 Lossless (``"1.2.840.10008.1.2.4.90"``)
+            and JPEG-LS Lossless (``"1.2.840.10008.1.2.4.80"``).
         **kwargs: Any, optional
             Additional keyword arguments that will be passed to the constructor
             of `highdicom.base.SOPClass`
@@ -445,6 +469,17 @@ class LegacyConvertedEnhancedMRImage(SOPClass):
 
         sop_class_uid = LEGACY_ENHANCED_SOP_CLASS_UID_MAP[ref_ds.SOPClassUID]
 
+        supported_transfer_syntaxes = {
+            ImplicitVRLittleEndian,
+            ExplicitVRLittleEndian,
+            JPEG2000Lossless,
+            JPEGLSLossless,
+        }
+        if transfer_syntax_uid not in supported_transfer_syntaxes:
+            raise ValueError(
+                f'Transfer syntax "{transfer_syntax_uid}" is not supported'
+            )
+
         super().__init__(
             study_instance_uid=ref_ds.StudyInstanceUID,
             series_instance_uid=series_instance_uid,
@@ -454,7 +489,7 @@ class LegacyConvertedEnhancedMRImage(SOPClass):
             instance_number=instance_number,
             manufacturer=ref_ds.Manufacturer,
             modality=ref_ds.Modality,
-            transfer_syntax_uid=None,  # FIXME: frame encoding
+            transfer_syntax_uid=transfer_syntax_uid,
             patient_id=ref_ds.PatientID,
             patient_name=ref_ds.PatientName,
             patient_birth_date=ref_ds.PatientBirthDate,
@@ -483,6 +518,7 @@ class LegacyConvertedEnhancedCTImage(SOPClass):
         series_number: int,
         sop_instance_uid: str,
         instance_number: int,
+        transfer_syntax_uid: str = ExplicitVRLittleEndian,
         **kwargs: Any
     ) -> None:
         """
@@ -499,6 +535,11 @@ class LegacyConvertedEnhancedCTImage(SOPClass):
             UID that should be assigned to the instance
         instance_number: int
             Number that should be assigned to the instance
+        transfer_syntax_uid: str, optional
+            UID of transfer syntax that should be used for encoding of
+            data elements. The following compressed transfer syntaxes
+            are supported: JPEG 2000 Lossless (``"1.2.840.10008.1.2.4.90"``)
+            and JPEG-LS Lossless (``"1.2.840.10008.1.2.4.80"``).
         **kwargs: Any, optional
             Additional keyword arguments that will be passed to the constructor
             of `highdicom.base.SOPClass`
@@ -530,7 +571,7 @@ class LegacyConvertedEnhancedCTImage(SOPClass):
             instance_number=instance_number,
             manufacturer=ref_ds.Manufacturer,
             modality=ref_ds.Modality,
-            transfer_syntax_uid=None,  # FIXME: frame encoding
+            transfer_syntax_uid=transfer_syntax_uid,
             patient_id=ref_ds.PatientID,
             patient_name=ref_ds.PatientName,
             patient_birth_date=ref_ds.PatientBirthDate,
@@ -550,14 +591,15 @@ class LegacyConvertedEnhancedPETImage(SOPClass):
     """SOP class for Legacy Converted Enhanced PET Image instances."""
 
     def __init__(
-            self,
-            legacy_datasets: Sequence[Dataset],
-            series_instance_uid: str,
-            series_number: int,
-            sop_instance_uid: str,
-            instance_number: int,
-            **kwargs: Any
-        ) -> None:
+        self,
+        legacy_datasets: Sequence[Dataset],
+        series_instance_uid: str,
+        series_number: int,
+        sop_instance_uid: str,
+        instance_number: int,
+        transfer_syntax_uid: str = ExplicitVRLittleEndian,
+        **kwargs: Any
+    ) -> None:
         """
         Parameters
         ----------
@@ -572,6 +614,11 @@ class LegacyConvertedEnhancedPETImage(SOPClass):
             UID that should be assigned to the instance
         instance_number: int
             Number that should be assigned to the instance
+        transfer_syntax_uid: str, optional
+            UID of transfer syntax that should be used for encoding of
+            data elements. The following compressed transfer syntaxes
+            are supported: JPEG 2000 Lossless (``"1.2.840.10008.1.2.4.90"``)
+            and JPEG-LS Lossless (``"1.2.840.10008.1.2.4.80"``).
         **kwargs: Any, optional
             Additional keyword arguments that will be passed to the constructor
             of `highdicom.base.SOPClass`
@@ -594,6 +641,17 @@ class LegacyConvertedEnhancedPETImage(SOPClass):
 
         sop_class_uid = LEGACY_ENHANCED_SOP_CLASS_UID_MAP[ref_ds.SOPClassUID]
 
+        supported_transfer_syntaxes = {
+            ImplicitVRLittleEndian,
+            ExplicitVRLittleEndian,
+            JPEG2000Lossless,
+            JPEGLSLossless,
+        }
+        if transfer_syntax_uid not in supported_transfer_syntaxes:
+            raise ValueError(
+                f'Transfer syntax "{transfer_syntax_uid}" is not supported'
+            )
+
         super().__init__(
             study_instance_uid=ref_ds.StudyInstanceUID,
             series_instance_uid=series_instance_uid,
@@ -603,7 +661,7 @@ class LegacyConvertedEnhancedPETImage(SOPClass):
             instance_number=instance_number,
             manufacturer=ref_ds.Manufacturer,
             modality=ref_ds.Modality,
-            transfer_syntax_uid=None,  # FIXME: frame encoding
+            transfer_syntax_uid=transfer_syntax_uid,
             patient_id=ref_ds.PatientID,
             patient_name=ref_ds.PatientName,
             patient_birth_date=ref_ds.PatientBirthDate,

--- a/src/highdicom/pm/sop.py
+++ b/src/highdicom/pm/sop.py
@@ -21,6 +21,7 @@ from pydicom.uid import (
     ExplicitVRLittleEndian,
     ImplicitVRLittleEndian,
     JPEG2000Lossless,
+    JPEGLSLossless,
     RLELossless,
 )
 from pydicom.valuerep import format_number_as_ds
@@ -175,8 +176,8 @@ class ParametricMap(SOPClass):
             stored values to be displayed on 8-bit monitors.
         transfer_syntax_uid: Union[str, None], optional
             UID of transfer syntax that should be used for encoding of
-            data elements. Defaults to Implicit VR Little Endian
-            (UID ``"1.2.840.10008.1.2"``)
+            data elements. Defaults to Explicit VR Little Endian
+            (UID ``"1.2.840.10008.1.2.1"``)
         content_description: Union[str, None], optional
             Brief description of the parametric map image
         content_creator_name: Union[str, None], optional
@@ -275,11 +276,10 @@ class ParametricMap(SOPClass):
             # If pixel data has unsigned or signed integer data type, then it
             # can be lossless compressed. The standard does not specify any
             # compression codecs for floating-point data types.
-            # In case of signed integer data type, values will be rescaled to
-            # a signed integer range prior to compression.
             supported_transfer_syntaxes.update(
                 {
                     JPEG2000Lossless,
+                    JPEGLSLossless,
                     RLELossless,
                 }
             )

--- a/src/highdicom/sc/sop.py
+++ b/src/highdicom/sc/sop.py
@@ -17,6 +17,7 @@ from pydicom.uid import (
     RLELossless,
     JPEGBaseline8Bit,
     JPEG2000Lossless,
+    JPEGLSLossless,
 )
 
 from highdicom.base import SOPClass
@@ -95,7 +96,7 @@ class SCImage(SOPClass):
             specimen_descriptions: Optional[
                 Sequence[SpecimenDescription]
             ] = None,
-            transfer_syntax_uid: str = ImplicitVRLittleEndian,
+            transfer_syntax_uid: str = ExplicitVRLittleEndian,
             **kwargs: Any
         ):
         """
@@ -172,7 +173,8 @@ class SCImage(SOPClass):
             UID of transfer syntax that should be used for encoding of
             data elements. The following compressed transfer syntaxes
             are supported: RLE Lossless (``"1.2.840.10008.1.2.5"``), JPEG
-            2000 Lossless (``"1.2.840.10008.1.2.4.90"``), JPEG Baseline
+            2000 Lossless (``"1.2.840.10008.1.2.4.90"``), JPEG-LS Lossless
+            (``"1.2.840.10008.1.2.4.80"``), and JPEG Baseline
             (``"1.2.840.10008.1.2.4.50"``). Note that JPEG Baseline is a
             lossy compression method that will lead to a loss of detail in
             the image.
@@ -187,6 +189,7 @@ class SCImage(SOPClass):
             RLELossless,
             JPEGBaseline8Bit,
             JPEG2000Lossless,
+            JPEGLSLossless,
         }
         if transfer_syntax_uid not in supported_transfer_syntaxes:
             raise ValueError(

--- a/src/highdicom/seg/sop.py
+++ b/src/highdicom/seg/sop.py
@@ -18,6 +18,7 @@ from pydicom.uid import (
     ExplicitVRLittleEndian,
     ImplicitVRLittleEndian,
     JPEG2000Lossless,
+    JPEGLSLossless,
     RLELossless,
     UID,
 )
@@ -290,6 +291,7 @@ class Segmentation(SOPClass):
             ImplicitVRLittleEndian,
             ExplicitVRLittleEndian,
             JPEG2000Lossless,
+            JPEGLSLossless,
             RLELossless,
         }
         if transfer_syntax_uid not in supported_transfer_syntaxes:

--- a/tests/test_sc.py
+++ b/tests/test_sc.py
@@ -8,7 +8,8 @@ from pydicom import dcmread
 from pydicom.uid import (
     RLELossless,
     JPEGBaseline8Bit,
-    JPEG2000Lossless
+    JPEG2000Lossless,
+    JPEGLSLossless,
 )
 from pydicom.valuerep import DA, TM
 
@@ -406,6 +407,61 @@ class TestSCImage(unittest.TestCase):
             self.get_array_after_writing(instance),
             frame
         )
+
+    def test_monochrome_jpegls(self):
+        bits_allocated = 16
+        photometric_interpretation = 'MONOCHROME2'
+        coordinate_system = 'PATIENT'
+        frame = np.random.randint(0, 2**16, size=(256, 256), dtype=np.uint16)
+        instance = SCImage(
+            pixel_array=frame,
+            photometric_interpretation=photometric_interpretation,
+            bits_allocated=bits_allocated,
+            coordinate_system=coordinate_system,
+            study_instance_uid=self._study_instance_uid,
+            series_instance_uid=self._series_instance_uid,
+            sop_instance_uid=self._sop_instance_uid,
+            series_number=self._series_number,
+            instance_number=self._instance_number,
+            manufacturer=self._manufacturer,
+            patient_orientation=self._patient_orientation,
+            transfer_syntax_uid=JPEGLSLossless
+        )
+
+        assert instance.file_meta.TransferSyntaxUID == JPEGLSLossless
+
+        assert np.array_equal(
+            self.get_array_after_writing(instance),
+            frame
+        )
+
+    def test_rgb_jpegls(self):
+        bits_allocated = 8
+        photometric_interpretation = 'YBR_FULL'
+        coordinate_system = 'PATIENT'
+        frame = np.random.randint(0, 256, size=(256, 256, 3), dtype=np.uint8)
+        instance = SCImage(
+            pixel_array=frame,
+            photometric_interpretation=photometric_interpretation,
+            bits_allocated=bits_allocated,
+            coordinate_system=coordinate_system,
+            study_instance_uid=self._study_instance_uid,
+            series_instance_uid=self._series_instance_uid,
+            sop_instance_uid=self._sop_instance_uid,
+            series_number=self._series_number,
+            instance_number=self._instance_number,
+            manufacturer=self._manufacturer,
+            patient_orientation=self._patient_orientation,
+            transfer_syntax_uid=JPEGLSLossless
+        )
+
+        assert instance.file_meta.TransferSyntaxUID == JPEGLSLossless
+
+        assert np.array_equal(
+            self.get_array_after_writing(instance),
+            frame
+        )
+
 
     def test_construct_rgb_from_ref_dataset(self):
         bits_allocated = 8

--- a/tests/test_seg.py
+++ b/tests/test_seg.py
@@ -14,7 +14,8 @@ from pydicom.uid import (
     ExplicitVRLittleEndian,
     ImplicitVRLittleEndian,
     RLELossless,
-    JPEG2000Lossless
+    JPEG2000Lossless,
+    JPEGLSLossless,
 )
 
 from highdicom.content import (
@@ -1249,7 +1250,8 @@ class TestSegmentation(unittest.TestCase):
                 ExplicitVRLittleEndian,
                 ImplicitVRLittleEndian,
                 RLELossless,
-                JPEG2000Lossless
+                JPEG2000Lossless,
+                JPEGLSLossless,
             ]
 
             max_fractional_value = 255


### PR DESCRIPTION
This PR will make it possible to encode and decode images using the JPEG-LS codec (which is much much fast than JPEG2000 for both encoding and decoding).

It would introduce additional dependencies:

1. **pillow-jpls**: enables reading/writing JPEG-LS images using the Pillow API
2. **pylibjpeg**: enables reading of JPEG, JPEG-LS, and JPEG-2000 compressed frames via pydicom
